### PR TITLE
Default to define name instead of manufacturer if raw device name doesn't contain spaces

### DIFF
--- a/custom_components/myuplink/entity.py
+++ b/custom_components/myuplink/entity.py
@@ -25,10 +25,13 @@ class MyUplinkEntity(CoordinatorEntity):
     def device_info(self):
         """Return the device_info of the device."""
         name_data = self._device.name.split()
-        name_data.reverse()
-        manufacturer = name_data.pop()
-        name_data.reverse()
-        model = " ".join(name_data)
+        manufacturer = None
+        model = name_data[0]
+        if len(name_data) > 1:
+            name_data.reverse()
+            manufacturer = name_data.pop()
+            name_data.reverse()
+            model = " ".join(name_data)
         return DeviceInfo(
             identifiers={(DOMAIN, self._device.id)},
             manufacturer=manufacturer,

--- a/custom_components/myuplink/entity.py
+++ b/custom_components/myuplink/entity.py
@@ -25,13 +25,12 @@ class MyUplinkEntity(CoordinatorEntity):
     def device_info(self):
         """Return the device_info of the device."""
         name_data = self._device.name.split()
-        manufacturer = None
         model = name_data[0]
+        manufacturer = None
         if len(name_data) > 1:
-            name_data.reverse()
-            manufacturer = name_data.pop()
-            name_data.reverse()
-            model = " ".join(name_data)
+            # Assumes last word in raw name is manufacturer
+            model = " ".join(name_data[:-1])
+            manufacturer = name_data[-1]
         return DeviceInfo(
             identifiers={(DOMAIN, self._device.id)},
             manufacturer=manufacturer,

--- a/custom_components/myuplink/entity.py
+++ b/custom_components/myuplink/entity.py
@@ -28,9 +28,9 @@ class MyUplinkEntity(CoordinatorEntity):
         model = name_data[0]
         manufacturer = None
         if len(name_data) > 1:
-            # Assumes last word in raw name is manufacturer
-            model = " ".join(name_data[:-1])
-            manufacturer = name_data[-1]
+            # Assumes first word in raw name is manufacturer
+            model = " ".join(name_data[1:])
+            manufacturer = name_data[0]
         return DeviceInfo(
             identifiers={(DOMAIN, self._device.id)},
             manufacturer=manufacturer,


### PR DESCRIPTION
Seems like there isn't any standard among myUplink devices of providing manufacturer name. The raw product.name for my Høyax is a long seemingly random string of letters/numbers, so I made it so that defining model is prioritized over manufacturer if there are no spaces.