### PR TITLE
Show value as text in Enum params rather than number

### DIFF
--- a/custom_components/myuplink/sensor.py
+++ b/custom_components/myuplink/sensor.py
@@ -56,15 +56,10 @@ class MyUplinkParameterSensorEntity(MyUplinkParameterEntity, SensorEntity):
         if len(parameter.enum_values):
             self._attr_device_class = SensorDeviceClass.ENUM
             self._attr_translation_key = self._parameter.id
+            self._attr_native_value = parameter.string_value
             self._attr_options = []
-            # Get enum text among possible enums
             for option in parameter.enum_values:
                 self._attr_options.append(option["text"])
-                if option["value"] == str(int(self._parameter.value)):
-                    self._attr_native_value = option["text"]
-                    break
-            else:
-                self._attr_native_value = str(int(self._parameter.value))
 
         else:
             self._attr_native_unit_of_measurement = self._parameter.unit

--- a/custom_components/myuplink/sensor.py
+++ b/custom_components/myuplink/sensor.py
@@ -56,10 +56,15 @@ class MyUplinkParameterSensorEntity(MyUplinkParameterEntity, SensorEntity):
         if len(parameter.enum_values):
             self._attr_device_class = SensorDeviceClass.ENUM
             self._attr_translation_key = self._parameter.id
-            self._attr_native_value = str(int(self._parameter.value))
             self._attr_options = []
+            # Get enum text among possible enums
             for option in parameter.enum_values:
-                self._attr_options.append(str(int(option["value"])))
+                self._attr_options.append(option["text"])
+                if option["value"] == str(int(self._parameter.value)):
+                    self._attr_native_value = option["text"]
+                    break
+            else:
+                self._attr_native_value = str(int(self._parameter.value))
 
         else:
             self._attr_native_unit_of_measurement = self._parameter.unit


### PR DESCRIPTION
Made sensors with device classes set as ENUM get human readable strings from raw data rather than integers.

Since the human readable enum-values are included in the raw data, it was pretty straight forward to implement. I put the logic into an existing loop, so shouldn't be much more expensive either.

I've tested it and it works as it should, see images below.

Before:
![bilde](https://user-images.githubusercontent.com/16783057/230987602-aa1d5217-5a02-486c-8d28-acb7bf36b668.png)


After:
![Screenshot from 2023-04-10 22-02-16](https://user-images.githubusercontent.com/16783057/230987430-8be4d104-5492-481f-a865-75c83f637e1e.png)
