### PR TITLE
Added new controllable platforms

### DIFF
--- a/custom_components/myuplink/api.py
+++ b/custom_components/myuplink/api.py
@@ -123,11 +123,17 @@ class Parameter:
         return self.raw_data["enumValues"]
 
     @property
+    def scale_value(self) -> str:
+        """Return the enum values of the parameter."""
+        return self.raw_data["scaleValue"]
+
+    @property
     def zone_id(self) -> str:
         """Return the zone id of the parameter."""
         return self.raw_data["zoneId"]
 
     async def update_parameter(self, value) -> None:
+        """Patch parameter if writable"""
         if not self.is_writable:
             return
         await self.device.api.patch_parameter(self.device.id, str(self.id), str(value))

--- a/custom_components/myuplink/api.py
+++ b/custom_components/myuplink/api.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import json
 
 from aiohttp import ClientSession, ClientResponse
 from datetime import datetime, timedelta
@@ -35,7 +36,7 @@ class AsyncConfigEntryAuth:
 
     async def request(self, method, path, **kwargs) -> ClientResponse:
         """Make an authorized request."""
-        headers = kwargs.get("headers")
+        headers = kwargs.pop("headers", None)
 
         if headers is None:
             headers = {}
@@ -56,9 +57,10 @@ class AsyncConfigEntryAuth:
 class Parameter:
     """Class that represents a parameter object in the myUplink API."""
 
-    def __init__(self, raw_data: dict) -> None:
+    def __init__(self, raw_data: dict, device: Device) -> None:
         """Initialize a parameter object."""
         self.raw_data = raw_data
+        self.device = device
 
     @property
     def category(self) -> str:
@@ -108,12 +110,12 @@ class Parameter:
     @property
     def min_value(self) -> int:
         """Return the min value of the parameter."""
-        return self.raw_data["minVal"]
+        return self.raw_data["minValue"]
 
     @property
     def max_value(self) -> int:
         """Return the max value of the parameter."""
-        return self.raw_data["maxVal"]
+        return self.raw_data["maxValue"]
 
     @property
     def enum_values(self) -> list[dict]:
@@ -124,6 +126,11 @@ class Parameter:
     def zone_id(self) -> str:
         """Return the zone id of the parameter."""
         return self.raw_data["zoneId"]
+
+    async def update_parameter(self, value) -> None:
+        if not self.is_writable:
+            return
+        await self.device.api.patch_parameter(self.device.id, str(self.id), str(value))
 
 
 class Zone:
@@ -252,7 +259,7 @@ class Device:
 
     async def async_fetch_data(self) -> None:
         """Fetch data from myUplink API."""
-        self.parameters = await self.api.get_parameters(self.id)
+        self.parameters = await self.api.get_parameters(self)
         self.zones = await self.api.get_zones(self.id)
 
 
@@ -296,7 +303,7 @@ class System:
 class Throttle:
     """Throttling requests to API."""
 
-    def __init__(self, delay):
+    def __init__(self, delay) -> None:
         """Initialize throttle"""
         self._delay = delay
         self._timestamp = datetime.now()
@@ -345,12 +352,12 @@ class MyUplink:
         resp.raise_for_status()
         return Device(resp.json(), self)
 
-    async def get_parameters(self, device_id) -> list[Parameter]:
+    async def get_parameters(self, device: Device) -> list[Parameter]:
         """Return all parameters for a device."""
         async with self.lock, self.throttle:
-            resp = await self.auth.request("get", f"devices/{device_id}/points")
+            resp = await self.auth.request("get", f"devices/{device.id}/points")
         resp.raise_for_status()
-        return [Parameter(parameter) for parameter in await resp.json()]
+        return [Parameter(parameter, device) for parameter in await resp.json()]
 
     async def get_zones(self, device_id) -> list[Zone]:
         """Return all smart home zones for a device."""
@@ -360,3 +367,15 @@ class MyUplink:
             )
         resp.raise_for_status()
         return [Zone(zone) for zone in await resp.json()]
+
+    async def patch_parameter(self, device_id, parameter_id: str, value: str) -> bool:
+        """Return all smart home zones for a device."""
+        async with self.lock, self.throttle:
+            resp = await self.auth.request(
+                "patch",
+                f"devices/{device_id}/points",
+                data=json.dumps({parameter_id: value}),
+                headers={"Content-Type": "application/json-patch+json"},
+            )
+        resp.raise_for_status()
+        return resp.status == 200

--- a/custom_components/myuplink/const.py
+++ b/custom_components/myuplink/const.py
@@ -18,9 +18,10 @@ SCOPES = [
 API_HOST = "https://api.myuplink.com"
 API_VERSION = "v2"
 
-PLATFORMS = [Platform.SENSOR, Platform.BINARY_SENSOR]
+PLATFORMS = [Platform.SENSOR, Platform.BINARY_SENSOR, Platform.WATER_HEATER]
 
 BINARY_SENSORS = [505, 506, 600, 7086, 10733, 10905, 10906]
+WATER_HEATERS = ["22044616"]
 
 
 class CustomUnits(StrEnum):

--- a/custom_components/myuplink/const.py
+++ b/custom_components/myuplink/const.py
@@ -18,10 +18,39 @@ SCOPES = [
 API_HOST = "https://api.myuplink.com"
 API_VERSION = "v2"
 
-PLATFORMS = [Platform.SENSOR, Platform.BINARY_SENSOR, Platform.WATER_HEATER]
+PLATFORMS = [
+    Platform.SENSOR,
+    Platform.BINARY_SENSOR,
+    Platform.WATER_HEATER,
+    Platform.SWITCH,
+    Platform.SELECT,
+    Platform.NUMBER,
+]
 
-BINARY_SENSORS = [505, 506, 600, 7086, 10733, 10905, 10906]
-WATER_HEATERS = ["22044616"]
+BINARY_SENSORS = [505, 506, 7086, 10733, 10905, 10906]
+SWITCHES = [600]
+SELECTS = [500, 517, 544, 601]
+NUMBERS = [
+    100,
+    101,
+    200,
+    201,
+    300,
+    301,
+    304,
+    305,
+    307,
+    308,
+    511,
+    512,
+    516,
+    527,
+    545,
+    546,
+    547,
+    548,
+]
+WATER_HEATERS = ["18760NE"]
 
 
 class CustomUnits(StrEnum):

--- a/custom_components/myuplink/number.py
+++ b/custom_components/myuplink/number.py
@@ -1,0 +1,67 @@
+"""Support for myUplink sensors."""
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.number import (
+    NumberEntity,
+    NumberDeviceClass,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.const import UnitOfTemperature
+
+from .api import Parameter
+from .const import DOMAIN, NUMBERS
+from .entity import MyUplinkParameterEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up the sensors."""
+
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    entities: list[NumberEntity] = []
+
+    for system in coordinator.data:
+        for device in system.devices:
+            for parameter in device.parameters:
+                if parameter.id in NUMBERS:
+                    entities.append(
+                        MyUplinkParameterNumberEntity(coordinator, device, parameter)
+                    )
+
+    async_add_entities(entities)
+
+
+class MyUplinkParameterNumberEntity(MyUplinkParameterEntity, NumberEntity):
+    """Representation of a myUplink paramater binary sensor."""
+
+    def _update_from_parameter(self, parameter: Parameter) -> None:
+        """Update attrs from parameter."""
+        super()._update_from_parameter(parameter)
+        unit_conversion = {
+            "°C": NumberDeviceClass.TEMPERATURE,
+            "°F": NumberDeviceClass.TEMPERATURE,
+        }
+        self._attr_device_class = unit_conversion.get(parameter.unit)
+
+        self._attr_native_unit_of_measurement = parameter.unit
+
+        if self._attr_device_class == NumberDeviceClass.TEMPERATURE:
+            self._attr_native_max_value = parameter.max_value / 100
+            self._attr_native_min_value = parameter.min_value / 100
+        else:
+            self._attr_native_max_value = parameter.max_value
+            self._attr_native_min_value = parameter.min_value
+        self._attr_native_step = float(parameter.scale_value)
+        self._attr_native_value = parameter.value
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Update the current value."""
+        await self._parameter.update_parameter(value)
+        await self.async_update()

--- a/custom_components/myuplink/select.py
+++ b/custom_components/myuplink/select.py
@@ -1,0 +1,55 @@
+"""Support for myUplink sensors."""
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .api import Parameter
+from .const import DOMAIN, SELECTS
+from .entity import MyUplinkParameterEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up the sensors."""
+
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    entities: list[SelectEntity] = []
+
+    for system in coordinator.data:
+        for device in system.devices:
+            for parameter in device.parameters:
+                if parameter.id in SELECTS:
+                    entities.append(
+                        MyUplinkParameterSelectEntity(coordinator, device, parameter)
+                    )
+
+    async_add_entities(entities)
+
+
+class MyUplinkParameterSelectEntity(MyUplinkParameterEntity, SelectEntity):
+    """Representation of a myUplink paramater binary sensor."""
+
+    def _update_from_parameter(self, parameter: Parameter) -> None:
+        """Update attrs from parameter."""
+        super()._update_from_parameter(parameter)
+        options = []
+        for enum in parameter.enum_values:
+            options.append(enum["text"])
+        self._attr_options = options
+        self._attr_current_option = parameter.string_value
+
+    async def async_select_option(self, option: str) -> None:
+        """Change the selected option."""
+        options = {}
+        for enum in self._parameter.enum_values:
+            options[enum["text"]] = enum["value"]
+        await self._parameter.update_parameter(options[option])
+        await self.async_update()

--- a/custom_components/myuplink/sensor.py
+++ b/custom_components/myuplink/sensor.py
@@ -20,7 +20,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .api import Parameter
-from .const import DOMAIN, BINARY_SENSORS, CustomUnits
+from .const import DOMAIN, BINARY_SENSORS, SWITCHES, SELECTS, NUMBERS, CustomUnits
 from .entity import MyUplinkParameterEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -37,7 +37,7 @@ async def async_setup_entry(
     for system in coordinator.data:
         for device in system.devices:
             for parameter in device.parameters:
-                if parameter.id not in BINARY_SENSORS:
+                if parameter.id not in BINARY_SENSORS + SWITCHES + SELECTS + NUMBERS:
                     entities.append(
                         MyUplinkParameterSensorEntity(coordinator, device, parameter)
                     )

--- a/custom_components/myuplink/switch.py
+++ b/custom_components/myuplink/switch.py
@@ -1,0 +1,55 @@
+"""Support for myUplink sensors."""
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .api import Parameter
+from .const import DOMAIN, SWITCHES
+from .entity import MyUplinkParameterEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up the sensors."""
+
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    entities: list[SwitchEntity] = []
+
+    for system in coordinator.data:
+        for device in system.devices:
+            for parameter in device.parameters:
+                if parameter.id in SWITCHES:
+                    entities.append(
+                        MyUplinkParameterSwitchEntityEntity(
+                            coordinator, device, parameter
+                        )
+                    )
+
+    async_add_entities(entities)
+
+
+class MyUplinkParameterSwitchEntityEntity(MyUplinkParameterEntity, SwitchEntity):
+    """Representation of a myUplink paramater binary sensor."""
+
+    def _update_from_parameter(self, parameter: Parameter) -> None:
+        """Update attrs from parameter."""
+        super()._update_from_parameter(parameter)
+        self._attr_is_on = bool(int(self._parameter.value))
+
+    async def async_turn_on(self, **kwargs):
+        """Turn the entity on."""
+        await self._parameter.update_parameter(1)
+        await self.async_update()
+
+    async def async_turn_off(self, **kwargs):
+        """Turn the entity off."""
+        await self._parameter.update_parameter(0)
+        await self.async_update()

--- a/custom_components/myuplink/water_heater.py
+++ b/custom_components/myuplink/water_heater.py
@@ -32,7 +32,7 @@ async def async_setup_entry(
 
     for system in coordinator.data:
         for device in system.devices:
-            if device.serial_number in WATER_HEATERS:
+            if device.name[:7] in WATER_HEATERS:
                 entities.append(MyUplinkWaterHeaterEntity(coordinator, device))
 
     async_add_entities(entities)

--- a/custom_components/myuplink/water_heater.py
+++ b/custom_components/myuplink/water_heater.py
@@ -1,0 +1,102 @@
+"""Support for myUplink sensors."""
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.water_heater import (
+    WaterHeaterEntity,
+    WaterHeaterEntityFeature,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import UnitOfTemperature
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.core import callback
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from .api import Parameter, Device
+from .const import DOMAIN, WATER_HEATERS
+from .entity import MyUplinkEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up the sensors."""
+
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    entities: list[WaterHeaterEntity] = []
+
+    for system in coordinator.data:
+        for device in system.devices:
+            if device.serial_number in WATER_HEATERS:
+                entities.append(MyUplinkWaterHeaterEntity(coordinator, device))
+
+    async_add_entities(entities)
+
+
+class MyUplinkWaterHeaterEntity(MyUplinkEntity, WaterHeaterEntity):
+    """Representation of a myUplink paramater binary sensor."""
+
+    def __init__(self, coordinator: DataUpdateCoordinator, device: Device) -> None:
+        super().__init__(coordinator, device)
+        self._update_from_parameters()
+
+    def _update_from_parameters(self) -> None:
+        """Update attrs from parameter."""
+        # super()._update_from_parameter(parameter)
+        parameter_map: dict[int, Parameter] = {}
+        for parameter in self._device.parameters:
+            parameter_map[parameter.id] = parameter
+        # for some reason the min_value is formated like this: "2000" = 20.00 Celcius
+        min_value = str(parameter_map[527].min_value)
+        max_value = str(parameter_map[527].max_value)
+        self._attr_min_temp = int(float(min_value[:-2] + "." + min_value[-2:]))
+        self._attr_max_temp = int(float(max_value[:-2] + "." + max_value[-2:]))
+        self._attr_current_temperature = parameter_map[528].value
+        self._attr_target_temperature = parameter_map[527].value
+        self._attr_target_temperature_high = self._attr_target_temperature
+        self._attr_target_temperature_low = (
+            self._attr_target_temperature - parameter_map[516].value
+        )
+        self._attr_temperature_unit = UnitOfTemperature.CELSIUS
+        operation_types = []
+        for enum in parameter_map[500].enum_values:
+            operation_types.append(enum["text"])
+        self._attr_current_operation = parameter_map[406].string_value
+        self._attr_operation_list = operation_types
+        self._attr_supported_features = (
+            WaterHeaterEntityFeature.TARGET_TEMPERATURE
+            | WaterHeaterEntityFeature.OPERATION_MODE
+        )
+
+    async def async_set_temperature(self, temperature: float, entity_id: str) -> None:
+        """Update the current value."""
+        for parameter in self._device.parameters:
+            if parameter.id == 527:
+                await parameter.update_parameter(temperature)
+        await self.async_update()
+
+    async def async_set_operation_mode(self, operation_mode: str) -> None:
+        """Update the current value."""
+        for parameter in self._device.parameters:
+            if parameter.id == 500:
+                operation_types = {}
+                for enum in parameter.enum_values:
+                    operation_types[enum["text"]] = enum["value"]
+                await parameter.update_parameter(operation_types[operation_mode])
+        await self.async_update()
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        for system in self.coordinator.data:
+            for device in system.devices:
+                if device.id == self._device.id:
+                    super()._update_from_device(device)
+                    self._update_from_parameters()
+
+        super().async_write_ha_state()


### PR DESCRIPTION
I decided to have a go at enabling the integration to control its devices. This included a few deep changes to the API, which works, but I have no idea if I'm following HASS conventions. Maybe there are no conventions?

Nonetheless, the integration now adds a water_heater for the Høiax CONNECTED lineup, and adds each parameter as a fitting user-editable entity if the API specifies the parameter as writable.

This is all based on parameter.id checks on the const.py file though. It'd be more ideal to have a function check the parameter's details to determine what kind of entity it should be, so it'd work for more devices. Maybe this should be implemented before merge?