### PR TITLE
Use scaleValue from api

### DIFF
--- a/custom_components/myuplink/api.py
+++ b/custom_components/myuplink/api.py
@@ -119,14 +119,22 @@ class Parameter:
         return self.raw_data["maxValue"]
 
     @property
+    def step_value(self) -> int:
+        """Return the step value of the parameter."""
+        return self.raw_data["stepValue"]
+
+    @property
     def enum_values(self) -> list[dict]:
         """Return the enum values of the parameter."""
         return self.raw_data["enumValues"]
 
     @property
-    def scale_value(self) -> str:
-        """Return the enum values of the parameter."""
-        return self.raw_data["scaleValue"]
+    def scale_value(self) -> float | None:
+        """Return the scale value of the parameter."""
+        if self.raw_data["scaleValue"]:
+            return float(self.raw_data["scaleValue"])
+
+        return 1.0
 
     @property
     def zone_id(self) -> str:

--- a/custom_components/myuplink/const.py
+++ b/custom_components/myuplink/const.py
@@ -1,7 +1,7 @@
 """Constants for the myUplink integration."""
 from __future__ import annotations
 
-from homeassistant.backports.enum import StrEnum
+from enum import StrEnum
 from homeassistant.const import Platform
 
 DOMAIN = "myuplink"

--- a/custom_components/myuplink/number.py
+++ b/custom_components/myuplink/number.py
@@ -52,13 +52,10 @@ class MyUplinkParameterNumberEntity(MyUplinkParameterEntity, NumberEntity):
 
         self._attr_native_unit_of_measurement = parameter.unit
 
-        if self._attr_device_class == NumberDeviceClass.TEMPERATURE:
-            self._attr_native_max_value = parameter.max_value / 100
-            self._attr_native_min_value = parameter.min_value / 100
-        else:
-            self._attr_native_max_value = parameter.max_value
-            self._attr_native_min_value = parameter.min_value
-        self._attr_native_step = float(parameter.scale_value)
+        self._attr_native_max_value = parameter.max_value * parameter.scale_value
+        self._attr_native_min_value = parameter.min_value * parameter.scale_value
+        self._attr_native_step = parameter.step_value * parameter.scale_value
+
         self._attr_native_value = parameter.value
 
     async def async_set_native_value(self, value: float) -> None:

--- a/custom_components/myuplink/water_heater.py
+++ b/custom_components/myuplink/water_heater.py
@@ -52,10 +52,12 @@ class MyUplinkWaterHeaterEntity(MyUplinkEntity, WaterHeaterEntity):
         for parameter in self._device.parameters:
             parameter_map[parameter.id] = parameter
         # for some reason the min_value is formated like this: "2000" = 20.00 Celcius
-        min_value = str(parameter_map[527].min_value)
-        max_value = str(parameter_map[527].max_value)
-        self._attr_min_temp = int(float(min_value[:-2] + "." + min_value[-2:]))
-        self._attr_max_temp = int(float(max_value[:-2] + "." + max_value[-2:]))
+        self._attr_min_temp = (
+            parameter_map[527].min_value * parameter_map[527].scale_value
+        )
+        self._attr_max_temp = (
+            parameter_map[527].max_value * parameter_map[527].scale_value
+        )
         self._attr_current_temperature = parameter_map[528].value
         self._attr_target_temperature = parameter_map[527].value
         self._attr_target_temperature_high = self._attr_target_temperature


### PR DESCRIPTION
As discovered in #21 the values for `minValue`, `maxValue` and `stepValue` are always provides as Integers even if they should support decimals. To accomplish this the `stepValue` as to be used as multiplier.

The following values provided by the API have to be modified:
```
"minValue": 50,
"maxValue": 300,
"stepValue": 5,
"scaleValue": "0.1",
```

Using the `scaleValue` of `0.1` as multiplier will result in a `minValue` of `5.0`, a `maxValue` of `30.0` and a `stepValue` of `0.5`.