### PR TITLE
Restore backported StrEnum for compatibility with python < 3.11

### DIFF
--- a/custom_components/myuplink/const.py
+++ b/custom_components/myuplink/const.py
@@ -1,7 +1,7 @@
 """Constants for the myUplink integration."""
 from __future__ import annotations
 
-from enum import StrEnum
+from homeassistant.backports.enum import StrEnum
 from homeassistant.const import Platform
 
 DOMAIN = "myuplink"


### PR DESCRIPTION
As some installations of home assistant are not yet on python 3.11, the `StrEnum` needs to use the backported implemenation.