### PR TITLE
Fix invalid response

### DIFF
--- a/custom_components/myuplink/api.py
+++ b/custom_components/myuplink/api.py
@@ -76,7 +76,7 @@ class Parameter:
     @property
     def name(self) -> str:
         """Return the name of the parameter."""
-        return self.raw_data["parameterName"]
+        return self.raw_data["parameterName"].replace("\xad", "")
 
     @property
     def unit(self) -> str:

--- a/custom_components/myuplink/sensor.py
+++ b/custom_components/myuplink/sensor.py
@@ -56,7 +56,7 @@ class MyUplinkParameterSensorEntity(MyUplinkParameterEntity, SensorEntity):
 
         if len(parameter.enum_values):
             self._attr_device_class = SensorDeviceClass.ENUM
-            self._attr_translation_key = self._parameter.id
+            self._attr_translation_key = str(self._parameter.id)
             self._attr_native_value = str(int(self._parameter.value))
             self._attr_options = []
             for option in parameter.enum_values:


### PR DESCRIPTION
As reported in #10 the request to Home Assistant API `config/entity_registry/list` end in an error as soon as the myUplink integration is configured.

Through debugging in the browser interface the following details have been found:
```
ZodError: [
  {
    "code": "invalid_type",
    "expected": "string",
    "received": "number",
    "path": [
      201,
      "translation_key"
    ],
    "message": "Expected string, received number"
  },
  {
    "code": "invalid_type",
    "expected": "string",
    "received": "number",
    "path": [
      218,
      "translation_key"
    ],
    "message": "Expected string, received number"
  },
  {
    "code": "invalid_type",
    "expected": "string",
    "received": "number",
    "path": [
      232,
      "translation_key"
    ],
    "message": "Expected string, received number"
  },
  {
    "code": "invalid_type",
    "expected": "string",
    "received": "number",
    "path": [
      233,
      "translation_key"
    ],
    "message": "Expected string, received number"
  }
]
    at get error [as error] (http://localhost:8123/hacsfiles/frigate-hass-card/card-555679fd.js:75:37985)
    at Object.invokeGetter (<anonymous>:3:28)
    at cp (http://localhost:8123/hacsfiles/frigate-hass-card/card-555679fd.js:75:138544)
    at async nb.fetchEntityList (http://localhost:8123/hacsfiles/frigate-hass-card/card-555679fd.js:507:2764)
    at async _v.initializeCameras (http://localhost:8123/hacsfiles/frigate-hass-card/card-555679fd.js:75:178964)
    at async kb._initializeCameras (http://localhost:8123/hacsfiles/frigate-hass-card/card-555679fd.js:507:25437)
    at async http://localhost:8123/hacsfiles/frigate-hass-card/card-555679fd.js:507:26917
    at async sb.initializeIfNecessary (http://localhost:8123/hacsfiles/frigate-hass-card/card-555679fd.js:507:7148)
```

As described, there are entities that deliver an Interger value as 'translation_key' but this hast to be a String.

This merge request will fix this.
