### PR TITLE
Initial Troubleshooting section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,29 +29,29 @@ Start the myUplink integration setup and copy the Client Identifier and Client S
 
 Next, approve access via the OAuth pop-up and you should be good to go!
 
-### Troubleshooting
+## Troubleshooting
 
 Reading this might help if you run into issues
 
-#### "Sorry, there was an error : invalid_request"
+### "Sorry, there was an error : invalid_request"
 
 This often means that the Callback URL provided is invalid or unreachable.
 
 Double-check that the Callback URL saved in the myUpLink application is correct.
 
-#### "Sorry, there was an error : unauthorized_client"
+### "Sorry, there was an error : unauthorized_client"
 
 This means that the credentials used by the integration is invalid. This often occurs when the myuplink-application is deleted and recreated, without deleting the old credentials from Home Assistant.
 
 You can delete the old credentials stored in Home Assistant by going to the Devices & Services page, clicking the three dots top right and selecting "Application Credentials". Delete the one originating from myuplink, and you'll be prompted for new credentials next time you set up the integration.
 
-#### Some entities don't look right
+### Some entities don't look right
 
 This can happen when the device is integrated poorly with the myUpLink-API, or it's implemented in a way this integration cannot handle yet.
 
 See the debugging section below to find some useful info about the offending data point.
 
-### Debugging misbehaving entities
+## Debugging misbehaving entities
 
 If the your entities are malformed, it's often caused by the manufacturer's implementation of the myUpLink-API. The easiest way to check this is by getting the raw data points from the Swagger client.
 

--- a/README.md
+++ b/README.md
@@ -28,3 +28,34 @@ _Note: You cannot edit the Callback Url after the application has been created, 
 Start the myUplink integration setup and copy the Client Identifier and Client Secret from your myUplink-application into the OAuth text fields.
 
 Next, approve access via the OAuth pop-up and you should be good to go!
+
+### Troubleshooting
+
+Reading this might help if you run into issues
+
+#### "Sorry, there was an error : invalid_request"
+
+This often means that the Callback URL provided is invalid or unreachable.
+
+Double-check that the Callback URL saved in the myUpLink application is correct.
+
+#### "Sorry, there was an error : unauthorized_client"
+
+This means that the credentials used by the integration is invalid. This often occurs when the myuplink-application is deleted and recreated, without deleting the old credentials from Home Assistant.
+
+You can delete the old credentials by going to the Devices & Services page, clicking the three dots top right and selecting "Application Credentials". Delete the one originating from myuplink, and you'll be prompted for new credentials next time you set up the integration.
+
+#### Some entities don't look right
+
+This can happen when the device is integrated poorly with the myUpLink-API. Maybe you'll see a wrong unit, or a mutable entity that should be immutable or the other way around.
+
+See the debugging section below to find some useful info about the offending data point.
+
+### Debugging misbehaving entities
+
+If the your entities are malformed, it's often caused by the manufacturer's implementation of the myUpLink-API. The easiest way to check this is by getting the raw data points from the Swagger client.
+
+1. Take note of the entity's name, and open [myUpLink's Swagger](https://api.myuplink.com/swagger/index.html).
+2. Click Authorize and paste your application credentials. Make sure to check the READSYSTEM box.
+3. Find your device ID by querying ​`/v2​/systems​/me`, and enter it when querying `/v2/devices/{deviceId}/points`.
+4. Find the relevant data points and post them in an issue.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Start the myUplink integration setup and copy the Client Identifier and Client S
 
 Next, approve access via the OAuth pop-up and you should be good to go!
 
-### Troubleshooting
+### Troubleshooting
 
 Reading this might help if you run into issues
 

--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ Double-check that the Callback URL saved in the myUpLink application is correct.
 
 This means that the credentials used by the integration is invalid. This often occurs when the myuplink-application is deleted and recreated, without deleting the old credentials from Home Assistant.
 
-You can delete the old credentials by going to the Devices & Services page, clicking the three dots top right and selecting "Application Credentials". Delete the one originating from myuplink, and you'll be prompted for new credentials next time you set up the integration.
+You can delete the old credentials stored in Home Assistant by going to the Devices & Services page, clicking the three dots top right and selecting "Application Credentials". Delete the one originating from myuplink, and you'll be prompted for new credentials next time you set up the integration.
 
 #### Some entities don't look right
 
-This can happen when the device is integrated poorly with the myUpLink-API. Maybe you'll see a wrong unit, or a mutable entity that should be immutable or the other way around.
+This can happen when the device is integrated poorly with the myUpLink-API, or it's implemented in a way this integration cannot handle yet.
 
 See the debugging section below to find some useful info about the offending data point.
 


### PR DESCRIPTION
There have been some similar issues coming up. Thought they could be mitigated by adding a "common issues" section in the readme. It would also pair well with an issue template imploring users to check the README section before posting.

I've written in the last part that the small quirks and badly implemented api can be recorded with Swagger and posted to issues. Is there an easy way to implement a system fixing small quirks like these? Maybe it should be up to the manufacturer/myUpLink to fix? idk