### PR TITLE
Use text representation of enum options

### DIFF
--- a/custom_components/myuplink/select.py
+++ b/custom_components/myuplink/select.py
@@ -41,10 +41,10 @@ class MyUplinkParameterSelectEntity(MyUplinkParameterEntity, SelectEntity):
     def _update_from_parameter(self, parameter: Parameter) -> None:
         """Update attrs from parameter."""
         super()._update_from_parameter(parameter)
-        options = []
+        self._attr_translation_key = str(self._parameter.id)
+        self._attr_options = []
         for enum in parameter.enum_values:
-            options.append(enum["text"])
-        self._attr_options = options
+            self._attr_options.append(enum["text"])
         self._attr_current_option = parameter.string_value
 
     async def async_select_option(self, option: str) -> None:

--- a/custom_components/myuplink/sensor.py
+++ b/custom_components/myuplink/sensor.py
@@ -53,15 +53,14 @@ class MyUplinkParameterSensorEntity(MyUplinkParameterEntity, SensorEntity):
     def _update_from_parameter(self, parameter: Parameter) -> None:
         """Update attrs from parameter."""
         super()._update_from_parameter(parameter)
-        self._attr_native_value = self._parameter.value
 
         if len(parameter.enum_values):
             self._attr_device_class = SensorDeviceClass.ENUM
             self._attr_translation_key = str(self._parameter.id)
-            self._attr_native_value = str(int(self._parameter.value))
             self._attr_options = []
             for option in parameter.enum_values:
-                self._attr_options.append(str(int(option["value"])))
+                self._attr_options.append(option["text"])
+            self._attr_native_value = self._parameter.string_value
 
         else:
             self._attr_native_unit_of_measurement = self._parameter.unit
@@ -91,3 +90,5 @@ class MyUplinkParameterSensorEntity(MyUplinkParameterEntity, SensorEntity):
                 self._attr_device_class = "degree_minutes"
             elif self._parameter.unit in (PERCENTAGE, CustomUnits.VOLUME_LM):
                 self._attr_icon = "mdi:speedometer"
+
+            self._attr_native_value = self._parameter.value

--- a/custom_components/myuplink/strings.json
+++ b/custom_components/myuplink/strings.json
@@ -33,7 +33,19 @@
           "8": "External",
           "9": "Legionella",
           "10": "Vacation",
-          "11": "Boost"
+          "11": "Boost",
+          "Boost": "Boost",
+          "Eco": "Eco",
+          "Express": "Express",
+          "External": "External",
+          "Legionella": "Legionella",
+          "Normal": "Normal",
+          "Off": "Off",
+          "Price": "Price",
+          "Schedule": "Schedule",
+          "Sleep": "Sleep",
+          "Test": "Test",
+          "Vacation": "Vacation"
         }
       },
       "500": {
@@ -44,7 +56,14 @@
           "7": "Schedule",
           "8": "External",
           "10": "Vacation",
-          "11": "Boost"
+          "11": "Boost",
+          "Boost": "Boost",
+          "Eco": "Eco",
+          "External": "External",
+          "Normal": "Normal",
+          "Price": "Price",
+          "Schedule": "Schedule",
+          "Vacation": "Vacation"
         }
       },
       "517": {
@@ -52,7 +71,10 @@
           "0": "0",
           "1": "700W",
           "2": "1300W",
-          "3": "2000W"
+          "3": "2000W",
+          "1300W": "1300W",
+          "2000W": "2000W",
+          "700W": "700W"
         }
       },
       "544": {
@@ -61,7 +83,12 @@
           "2": "NO2",
           "3": "NO3",
           "4": "NO4",
-          "5": "NO5"
+          "5": "NO5",
+          "NO1": "NO1",
+          "NO2": "NO2",
+          "NO3": "NO3",
+          "NO4": "NO4",
+          "NO5": "NO5"
         }
       },
       "549": {
@@ -69,12 +96,17 @@
           "0": "Unknown",
           "1": "Cheap",
           "2": "Normal",
-          "3": "Expensive"
+          "3": "Expensive",
+          "Cheap": "Cheap",
+          "Expensive": "Expensive",
+          "Normal": "Normal",
+          "Unknown": "Unknown"
         }
       },
       "601": {
         "state": {
-          "1": "heat"
+          "1": "heat",
+          "heat": "heat"
         }
       },
       "1965": {
@@ -83,9 +115,14 @@
           "40": "Starting",
           "60": "On",
           "100": "Stopping",
-          "120": "Defrost­ing",
-          "140": "Defrost­ing",
-          "160": "Defrost­ing"
+          "120": "Defrosting",
+          "140": "Defrosting",
+          "160": "Defrosting",
+          "Defrosting": "Defrosting",
+          "Off": "Off",
+          "On": "On",
+          "Starting": "Starting",
+          "Stopping": "Stopping"
         }
       },
       "14950": {
@@ -96,7 +133,14 @@
           "3": "Hot water",
           "4": "Pool",
           "5": "Pool 2",
-          "6": "Pre­heating"
+          "6": "Preheating",
+          "Cooling": "Cooling",
+          "Heating": "Heating",
+          "Hot water": "Hot water",
+          "Off": "Off",
+          "Pool 2": "Pool 2",
+          "Pool": "Pool",
+          "Preheating": "Preheating"
         }
       },
       "55000": {
@@ -107,7 +151,14 @@
           "40": "Pool",
           "41": "Pool 2",
           "50": "Transfer",
-          "60": "Cooling"
+          "60": "Cooling",
+          "Cooling": "Cooling",
+          "Heating": "Heating",
+          "Hot water": "Hot water",
+          "Off": "Off",
+          "Pool 2": "Pool 2",
+          "Pool": "Pool",
+          "Transfer": "Transfer"
         }
       },
       "55027": {
@@ -118,7 +169,11 @@
           "3": "Off",
           "4": "Blocked",
           "5": "Off",
-          "6": "Active"
+          "6": "Active",
+          "Active": "Active",
+          "Alarm": "Alarm",
+          "Blocked": "Blocked",
+          "Off": "Off"
         }
       }
     }

--- a/custom_components/myuplink/strings.json
+++ b/custom_components/myuplink/strings.json
@@ -33,19 +33,7 @@
           "8": "External",
           "9": "Legionella",
           "10": "Vacation",
-          "11": "Boost",
-          "Boost": "Boost",
-          "Eco": "Eco",
-          "Express": "Express",
-          "External": "External",
-          "Legionella": "Legionella",
-          "Normal": "Normal",
-          "Off": "Off",
-          "Price": "Price",
-          "Schedule": "Schedule",
-          "Sleep": "Sleep",
-          "Test": "Test",
-          "Vacation": "Vacation"
+          "11": "Boost"
         }
       },
       "500": {
@@ -56,14 +44,7 @@
           "7": "Schedule",
           "8": "External",
           "10": "Vacation",
-          "11": "Boost",
-          "Boost": "Boost",
-          "Eco": "Eco",
-          "External": "External",
-          "Normal": "Normal",
-          "Price": "Price",
-          "Schedule": "Schedule",
-          "Vacation": "Vacation"
+          "11": "Boost"
         }
       },
       "517": {
@@ -71,10 +52,7 @@
           "0": "0",
           "1": "700W",
           "2": "1300W",
-          "3": "2000W",
-          "1300W": "1300W",
-          "2000W": "2000W",
-          "700W": "700W"
+          "3": "2000W"
         }
       },
       "544": {
@@ -83,12 +61,7 @@
           "2": "NO2",
           "3": "NO3",
           "4": "NO4",
-          "5": "NO5",
-          "NO1": "NO1",
-          "NO2": "NO2",
-          "NO3": "NO3",
-          "NO4": "NO4",
-          "NO5": "NO5"
+          "5": "NO5"
         }
       },
       "549": {
@@ -96,17 +69,12 @@
           "0": "Unknown",
           "1": "Cheap",
           "2": "Normal",
-          "3": "Expensive",
-          "Cheap": "Cheap",
-          "Expensive": "Expensive",
-          "Normal": "Normal",
-          "Unknown": "Unknown"
+          "3": "Expensive"
         }
       },
       "601": {
         "state": {
-          "1": "heat",
-          "heat": "heat"
+          "1": "heat"
         }
       },
       "1965": {
@@ -117,12 +85,7 @@
           "100": "Stopping",
           "120": "Defrosting",
           "140": "Defrosting",
-          "160": "Defrosting",
-          "Defrosting": "Defrosting",
-          "Off": "Off",
-          "On": "On",
-          "Starting": "Starting",
-          "Stopping": "Stopping"
+          "160": "Defrosting"
         }
       },
       "14950": {
@@ -133,14 +96,7 @@
           "3": "Hot water",
           "4": "Pool",
           "5": "Pool 2",
-          "6": "Preheating",
-          "Cooling": "Cooling",
-          "Heating": "Heating",
-          "Hot water": "Hot water",
-          "Off": "Off",
-          "Pool 2": "Pool 2",
-          "Pool": "Pool",
-          "Preheating": "Preheating"
+          "6": "Preheating"
         }
       },
       "55000": {
@@ -151,14 +107,7 @@
           "40": "Pool",
           "41": "Pool 2",
           "50": "Transfer",
-          "60": "Cooling",
-          "Cooling": "Cooling",
-          "Heating": "Heating",
-          "Hot water": "Hot water",
-          "Off": "Off",
-          "Pool 2": "Pool 2",
-          "Pool": "Pool",
-          "Transfer": "Transfer"
+          "60": "Cooling"
         }
       },
       "55027": {
@@ -169,11 +118,7 @@
           "3": "Off",
           "4": "Blocked",
           "5": "Off",
-          "6": "Active",
-          "Active": "Active",
-          "Alarm": "Alarm",
-          "Blocked": "Blocked",
-          "Off": "Off"
+          "6": "Active"
         }
       }
     }

--- a/custom_components/myuplink/translations/de.json
+++ b/custom_components/myuplink/translations/de.json
@@ -26,9 +26,14 @@
           "40": "Startet",
           "60": "Ein",
           "100": "Stoppt",
-          "120": "Ent­eisung wird durch­geführt",
-          "140": "Ent­eisung wird durch­geführt",
-          "160": "Ent­eisung wird durch­geführt"
+          "120": "Enteisung wird durchgeführt",
+          "140": "Enteisung wird durchgeführt",
+          "160": "Enteisung wird durchgeführt",
+          "Defrosting": "Enteisung wird durchgeführt",
+          "Off": "Aus",
+          "On": "Ein",
+          "Starting": "Startet",
+          "Stopping": "Stoppt"
         }
       },
       "14950": {
@@ -39,7 +44,14 @@
           "3": "Brauchwasser",
           "4": "Pool",
           "5": "Pool 2",
-          "6": "Vor­wärmung"
+          "6": "Vorwärmung",
+          "Cooling": "Kühlung",
+          "Heating": "Heizung",
+          "Hot water": "Brauchwasser",
+          "Off": "Aus",
+          "Pool 2": "Pool 2",
+          "Pool": "Pool",
+          "Preheating": "Vorwärmung"
         }
       },
       "55000": {
@@ -50,7 +62,14 @@
           "40": "Pool",
           "41": "Pool 2",
           "50": "Transfer",
-          "60": "Kühlung"
+          "60": "Kühlung",
+          "Cooling": "Kühlung",
+          "Heating": "Heizung",
+          "Hot water": "Brauchwasser",
+          "Off": "Aus",
+          "Pool 2": "Pool 2",
+          "Pool": "Pool",
+          "Transfer": "Transfer"
         }
       },
       "55027": {
@@ -61,7 +80,11 @@
           "3": "Aus",
           "4": "Blockiert",
           "5": "Aus",
-          "6": "Aktiv"
+          "6": "Aktiv",
+          "Active": "Aktiv",
+          "Alarm": "Alarm",
+          "Blocked": "Blockiert",
+          "Off": "Aus"
         }
       }
     }

--- a/custom_components/myuplink/translations/en.json
+++ b/custom_components/myuplink/translations/en.json
@@ -83,9 +83,9 @@
           "40": "Starting",
           "60": "On",
           "100": "Stopping",
-          "120": "Defrost­ing",
-          "140": "Defrost­ing",
-          "160": "Defrost­ing"
+          "120": "Defrosting",
+          "140": "Defrosting",
+          "160": "Defrosting"
         }
       },
       "14950": {
@@ -96,7 +96,7 @@
           "3": "Hot water",
           "4": "Pool",
           "5": "Pool 2",
-          "6": "Pre­heating"
+          "6": "Preheating"
         }
       },
       "55000": {

--- a/custom_components/myuplink/translations/nb.json
+++ b/custom_components/myuplink/translations/nb.json
@@ -33,7 +33,19 @@
           "8": "Ekstern",
           "9": "Legionella",
           "10": "Ferie",
-          "11": "Boost"
+          "11": "Boost",
+          "Boost": "Boost",
+          "Eco": "Øko",
+          "Express": "Ekspress",
+          "External": "Ekstern",
+          "Legionella": "Legionella",
+          "Normal": "Normal",
+          "Off": "Av",
+          "Price": "Pris",
+          "Schedule": "Timeplan",
+          "Sleep": "Hvilemodus",
+          "Test": "Test",
+          "Vacation": "Ferie"
         }
       },
       "500": {
@@ -44,7 +56,14 @@
           "7": "Timeplan",
           "8": "Ekstern",
           "10": "Ferie",
-          "11": "Boost"
+          "11": "Boost",
+          "Boost": "Boost",
+          "Eco": "Øko",
+          "External": "Ekstern",
+          "Normal": "Normal",
+          "Price": "Pris",
+          "Schedule": "Timeplan",
+          "Vacation": "Ferie"
         }
       },
       "517": {
@@ -69,12 +88,17 @@
           "0": "Ukjent",
           "1": "Billig",
           "2": "Normal",
-          "3": "Dyr"
+          "3": "Dyr",
+          "Cheap": "Billig",
+          "Expensive": "Dyr",
+          "Normal": "Normal",
+          "Unknown": "Ukjent"
         }
       },
       "601": {
         "state": {
-          "1": "varme"
+          "1": "varme",
+          "heat": "varme"
         }
       },
       "1965": {
@@ -85,7 +109,12 @@
           "100": "Stopper",
           "120": "Avrimer",
           "140": "Avrimer",
-          "160": "Avrimer"
+          "160": "Avrimer",
+          "Defrosting": "Avrimer",
+          "Off": "Av",
+          "On": "På",
+          "Starting": "Starter",
+          "Stopping": "Stopper"
         }
       },
       "14950": {
@@ -96,7 +125,14 @@
           "3": "Varmtvann",
           "4": "Pool",
           "5": "Pool 2",
-          "6": "Forvarmer"
+          "6": "Forvarmer",
+          "Cooling": "Avkjøler",
+          "Heating": "Varmer",
+          "Hot water": "Varmtvann",
+          "Off": "Av",
+          "Pool 2": "Pool 2",
+          "Pool": "Pool",
+          "Preheating": "Forvarmer"
         }
       },
       "55000": {
@@ -107,7 +143,14 @@
           "40": "Pool",
           "41": "Pool 2",
           "50": "Overføring",
-          "60": "Avkjøler"
+          "60": "Avkjøler",
+          "Cooling": "Avkjøling",
+          "Heating": "Varmer",
+          "Hot water": "Varmtvann",
+          "Off": "Av",
+          "Pool 2": "Pool 2",
+          "Pool": "Pool",
+          "Transfer": "Øverføring"
         }
       },
       "55027": {
@@ -118,7 +161,11 @@
           "3": "Av",
           "4": "Blokkert",
           "5": "Av",
-          "6": "Aktiv"
+          "6": "Aktiv",
+          "Active": "Aktiv",
+          "Alarm": "Alarm",
+          "Blocked": "Blokkert",
+          "Off": "Av"
         }
       }
     }

--- a/custom_components/myuplink/translations/sensor.de.json
+++ b/custom_components/myuplink/translations/sensor.de.json
@@ -5,9 +5,14 @@
       "40": "Startet",
       "60": "Ein",
       "100": "Stoppt",
-      "120": "Ent­eisung wird durch­geführt",
-      "140": "Ent­eisung wird durch­geführt",
-      "160": "Ent­eisung wird durch­geführt"
+      "120": "Enteisung wird durchgeführt",
+      "140": "Enteisung wird durchgeführt",
+      "160": "Enteisung wird durchgeführt",
+      "Defrosting": "Enteisung wird durchgeführt",
+      "Off": "Aus",
+      "On": "Ein",
+      "Starting": "Startet",
+      "Stopping": "Stoppt"
     },
     "myuplink__14950": {
       "0": "Aus",
@@ -16,7 +21,14 @@
       "3": "Brauchwasser",
       "4": "Pool",
       "5": "Pool 2",
-      "6": "Vor­wärmung"
+      "6": "Vorwärmung",
+      "Cooling": "Kühlung",
+      "Heating": "Heizung",
+      "Hot water": "Brauchwasser",
+      "Off": "Aus",
+      "Pool 2": "Pool 2",
+      "Pool": "Pool",
+      "Preheating": "Vorwärmung"
     },
     "myuplink__55000": {
       "10": "Aus",
@@ -25,7 +37,14 @@
       "40": "Pool",
       "41": "Pool 2",
       "50": "Transfer",
-      "60": "Kühlung"
+      "60": "Kühlung",
+      "Cooling": "Kühlung",
+      "Heating": "Heizung",
+      "Hot water": "Brauchwasser",
+      "Off": "Aus",
+      "Pool 2": "Pool 2",
+      "Pool": "Pool",
+      "Transfer": "Transfer"
     },
     "myuplink__55027": {
       "0": "Alarm",
@@ -34,7 +53,11 @@
       "3": "Aus",
       "4": "Blockiert",
       "5": "Aus",
-      "6": "Aktiv"
+      "6": "Aktiv",
+      "Active": "Aktiv",
+      "Alarm": "Alarm",
+      "Blocked": "Blockiert",
+      "Off": "Aus"
     }
   }
 }

--- a/custom_components/myuplink/translations/sensor.en.json
+++ b/custom_components/myuplink/translations/sensor.en.json
@@ -50,9 +50,9 @@
       "40": "Starting",
       "60": "On",
       "100": "Stopping",
-      "120": "Defrost­ing",
-      "140": "Defrost­ing",
-      "160": "Defrost­ing"
+      "120": "Defrosting",
+      "140": "Defrosting",
+      "160": "Defrosting"
     },
     "myuplink__14950": {
       "0": "Off",
@@ -61,7 +61,7 @@
       "3": "Hot water",
       "4": "Pool",
       "5": "Pool 2",
-      "6": "Pre­heating"
+      "6": "Preheating"
     },
     "myuplink__55000": {
       "10": "Off",

--- a/custom_components/myuplink/translations/sensor.nb.json
+++ b/custom_components/myuplink/translations/sensor.nb.json
@@ -12,7 +12,19 @@
       "8": "Ekstern",
       "9": "Legionella",
       "10": "Ferie",
-      "11": "Boost"
+      "11": "Boost",
+      "Boost": "Boost",
+      "Eco": "Øko",
+      "Express": "Ekspress",
+      "External": "Ekstern",
+      "Legionella": "Legionella",
+      "Normal": "Normal",
+      "Off": "Av",
+      "Price": "Pris",
+      "Schedule": "Timeplan",
+      "Sleep": "Hvilemodus",
+      "Test": "Test",
+      "Vacation": "Ferie"
     },
     "myuplink__500": {
       "3": "Øko",
@@ -21,7 +33,14 @@
       "7": "Timeplan",
       "8": "Ekstern",
       "10": "Ferie",
-      "11": "Boost"
+      "11": "Boost",
+      "Boost": "Boost",
+      "Eco": "Øko",
+      "External": "Ekstern",
+      "Normal": "Normal",
+      "Price": "Pris",
+      "Schedule": "Timeplan",
+      "Vacation": "Ferie"
     },
     "myuplink__517": {
       "0": "0",
@@ -40,10 +59,15 @@
       "0": "Ukjent",
       "1": "Billig",
       "2": "Normal",
-      "3": "Dyr"
+      "3": "Dyr",
+      "Cheap": "Billig",
+      "Expensive": "Dyr",
+      "Normal": "Normal",
+      "Unknown": "Ukjent"
     },
     "myuplink__601": {
-      "1": "varme"
+      "1": "varme",
+      "heat": "varme"
     },
     "myuplink__1965": {
       "20": "Av",
@@ -52,7 +76,12 @@
       "100": "Stopper",
       "120": "Avriming",
       "140": "Avriming",
-      "160": "Avriming"
+      "160": "Avriming",
+      "Defrosting": "Avrimer",
+      "Off": "Av",
+      "On": "På",
+      "Starting": "Starter",
+      "Stopping": "Stopper"
     },
     "myuplink__14950": {
       "0": "Av",
@@ -61,7 +90,14 @@
       "3": "Varmtvann",
       "4": "Pool",
       "5": "Pool 2",
-      "6": "Forvarmer"
+      "6": "Forvarmer",
+      "Cooling": "Avkjøler",
+      "Heating": "Varmer",
+      "Hot water": "Varmtvann",
+      "Off": "Av",
+      "Pool 2": "Pool 2",
+      "Pool": "Pool",
+      "Preheating": "Forvarmer"
     },
     "myuplink__55000": {
       "10": "Av",
@@ -70,7 +106,14 @@
       "40": "Pool",
       "41": "Pool 2",
       "50": "Øverføring",
-      "60": "Avkjøling"
+      "60": "Avkjøling",
+      "Cooling": "Avkjøling",
+      "Heating": "Varmer",
+      "Hot water": "Varmtvann",
+      "Off": "Av",
+      "Pool 2": "Pool 2",
+      "Pool": "Pool",
+      "Transfer": "Øverføring"
     },
     "myuplink__55027": {
       "0": "Alarm",
@@ -79,7 +122,11 @@
       "3": "Av",
       "4": "Blokkert",
       "5": "Av",
-      "6": "Aktiv"
+      "6": "Aktiv",
+      "Active": "Aktiv",
+      "Alarm": "Alarm",
+      "Blocked": "Blokkert",
+      "Off": "Av"
     }
   }
 }


### PR DESCRIPTION
Switch to use text representation of enum options (like already done in select entity) to initially show readable options instead of numeric values.

This should solve onboarding issues, where new (and currently unknown) devices with unknown enum options do only show numeric values nobody understands.

As we currently use the numeric values for states in history too, we need to preserve the original translations that allowed localization of enum options.

But there is one downside to this:

Nibe has currently some enum parameters that include redundant text values for different numeric option values like the following:
```
  {
    "category": "NIBE S1255-6 E PC EM 3X400V",
    "parameterId": "1965",
    "parameterName": "Oper­ating mode com­pressor",
    "parameterUnit": "",
    "writable": false,
    "timestamp": "2024-01-11T20:34:18+00:00",
    "value": 60,
    "strVal": "On",
    "smartHomeCategories": [],
    "minValue": null,
    "maxValue": null,
    "stepValue": 1,
    "enumValues": [
      {
        "value": "20",
        "text": "Off",
        "icon": ""
      },
      {
        "value": "40",
        "text": "Starting",
        "icon": ""
      },
      {
        "value": "60",
        "text": "On",
        "icon": ""
      },
      {
        "value": "100",
        "text": "Stop­ping",
        "icon": ""
      },
      {
        "value": "120",
        "text": "Defrost­ing",
        "icon": ""
      },
      {
        "value": "140",
        "text": "Defrost­ing",
        "icon": ""
      },
      {
        "value": "160",
        "text": "Defrost­ing",
        "icon": ""
      }
    ],
    "scaleValue": "1",
    "zoneId": null
  },
  {
    "category": "NIBE S1255-6 E PC EM 3X400V",
    "parameterId": "55027",
    "parameterName": "Int elec add heat",
    "parameterUnit": "",
    "writable": false,
    "timestamp": "2024-01-11T18:45:24+00:00",
    "value": 4,
    "strVal": "Blocked",
    "smartHomeCategories": [],
    "minValue": null,
    "maxValue": null,
    "stepValue": 1,
    "enumValues": [
      {
        "value": "0",
        "text": "Alarm",
        "icon": ""
      },
      {
        "value": "1",
        "text": "Alarm",
        "icon": ""
      },
      {
        "value": "2",
        "text": "Active",
        "icon": ""
      },
      {
        "value": "3",
        "text": "Off",
        "icon": ""
      },
      {
        "value": "4",
        "text": "Blocked",
        "icon": ""
      },
      {
        "value": "5",
        "text": "Off",
        "icon": ""
      },
      {
        "value": "6",
        "text": "Active",
        "icon": ""
      }
    ],
    "scaleValue": "1",
    "zoneId": null
  }
```

As soon as we use the text values of the options we can not differentiate the different states any more. But may be this ist noch that important, as Nibe seems not to bother with that too.