### PR TITLE
Add support for UPDATE platform tracking firmware updates

### DIFF
--- a/custom_components/myuplink/const.py
+++ b/custom_components/myuplink/const.py
@@ -25,6 +25,7 @@ PLATFORMS = [
     Platform.SWITCH,
     Platform.SELECT,
     Platform.NUMBER,
+    Platform.UPDATE,
 ]
 
 PLATFORM_OVERRIDE = {10733: Platform.BINARY_SENSOR, 44703: Platform.BINARY_SENSOR}

--- a/custom_components/myuplink/entity.py
+++ b/custom_components/myuplink/entity.py
@@ -36,7 +36,7 @@ class MyUplinkEntity(CoordinatorEntity):
             manufacturer=manufacturer,
             model=model,
             name=self._device.name,
-            sw_version=self._device.current_firmware_version,
+            sw_version=self._device.firmware_info.current_version,
         )
 
     @property

--- a/custom_components/myuplink/update.py
+++ b/custom_components/myuplink/update.py
@@ -1,0 +1,53 @@
+"""Support for myUplink update platform."""
+
+from homeassistant.components.update import UpdateEntity, UpdateEntityFeature
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .api import Device
+from .const import DOMAIN
+from .entity import MyUplinkEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up update entities."""
+
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    entities: list[UpdateEntity] = []
+
+    for system in coordinator.data:
+        for device in system.devices:
+            entities.append(MyUplinkUpdateEntity(coordinator, device))
+
+    async_add_entities(entities)
+
+
+class MyUplinkUpdateEntity(MyUplinkEntity, UpdateEntity):
+    """Representation of a myUplink update entity."""
+
+    _attr_supported_features = UpdateEntityFeature.PROGRESS
+
+    def _update_from_device(self, device: Device) -> None:
+        """Update attrs from device."""
+        super()._update_from_device(device)
+
+        self._attr_name = f"{self._device.name} Firmware"
+        self._attr_unique_id = f"{DOMAIN}_{device.id}_firmware"
+
+    @property
+    def installed_version(self) -> str | None:
+        """Version installed and in use."""
+        return self._device.firmware_info.current_version
+
+    @property
+    def latest_version(self) -> str | None:
+        """Latest version available for install."""
+        return self._device.firmware_info.desired_version
+
+    @property
+    def in_progress(self) -> bool:
+        """Update installation in progress."""
+        return self._device.firmware_info.pending_version != ""


### PR DESCRIPTION
Adding an firmware update entity for each device showing, current and latest firmware and if an update is in progress.

Utilizing the feature of https://www.home-assistant.io/integrations/update/