### PR TITLE
Add support for up to 99 systems

### DIFF
--- a/custom_components/myuplink/api.py
+++ b/custom_components/myuplink/api.py
@@ -392,7 +392,9 @@ class MyUplink:
         if not self.systems:
             _LOGGER.debug("Fetch systems")
             async with self.lock, self.throttle:
-                resp = await self.auth.request("get", "systems/me")
+                resp = await self.auth.request(
+                    "get", "systems/me?page=1&itemsPerPage=99"
+                )
             resp.raise_for_status()
             data = await resp.json()
 

--- a/custom_components/myuplink/manifest.json
+++ b/custom_components/myuplink/manifest.json
@@ -10,6 +10,6 @@
   "issue_tracker": "https://github.com/jaroschek/home-assistant-myuplink/issues",
   "requirements": [],
   "ssdp": [],
-  "version": "1.1.3",
+  "version": "1.1.4",
   "zeroconf": []
 }


### PR DESCRIPTION
As the myUplink API has a paging for the initial request of `/v2/systems/me`, there was a default limit of `10` systems. Although additional requests with usage of the available paging parameters would also be an option, the increase to the actual limit `99` was chosen.

This should also enhance the support for multiple systems https://github.com/jaroschek/home-assistant-myuplink/issues/44