### PR TITLE
Changed switch detection for entity regardless off casing

### DIFF
--- a/custom_components/myuplink/api.py
+++ b/custom_components/myuplink/api.py
@@ -160,8 +160,8 @@ class Parameter:
             return PLATFORM_OVERRIDE[self.id]
         on_off = (
             len(self.enum_values) == 2
-            and self.enum_values[0]["text"] == "Off"
-            and self.enum_values[1]["text"] == "On"
+            and lower(self.enum_values[0]["text"]) == "off"
+            and lower(self.enum_values[1]["text"]) == "on"
         )
         if on_off:
             if self.is_writable:


### PR DESCRIPTION
Some devices are returning their capabilities with lower case for switches instead of "On" and "Off"
Testing on lower cased version of the parameter should be compatible with all possibilities
Related to #77