### PR TITLE
Use '.lower()' instead of 'lower(...)'

### DIFF
--- a/custom_components/myuplink/api.py
+++ b/custom_components/myuplink/api.py
@@ -160,8 +160,8 @@ class Parameter:
             return PLATFORM_OVERRIDE[self.id]
         on_off = (
             len(self.enum_values) == 2
-            and lower(self.enum_values[0]["text"]) == "off"
-            and lower(self.enum_values[1]["text"]) == "on"
+            and self.enum_values[0]["text"].lower() == "off"
+            and self.enum_values[1]["text"].lower() == "on"
         )
         if on_off:
             if self.is_writable:


### PR DESCRIPTION
Unfortunately I did not see (and test) the latest proposed code change to fix #77 

That change causes the following error:
```log
2024-01-26 04:33:01.075 ERROR (MainThread) [homeassistant.components.number] Error while setting up myuplink platform for number
Traceback (most recent call last):
  File "/workspaces/home-assistant-core/homeassistant/helpers/entity_platform.py", line 326, in _async_setup_platform
    await asyncio.shield(task)
  File "/workspaces/home-assistant-core/config/custom_components/myuplink/number.py", line 30, in async_setup_entry
    if parameter.find_fitting_entity() == Platform.NUMBER:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/home-assistant-core/config/custom_components/myuplink/api.py", line 163, in find_fitting_entity
    and lower(self.enum_values[0]["text"]) == "off"
        ^^^^^
NameError: name 'lower' is not defined
```

We have to use `.lower()` as `lower(...)` is not defined.