### PR TITLE
Suppress possible asyncio.CancelledError on sleep task

### DIFF
--- a/custom_components/myuplink/api.py
+++ b/custom_components/myuplink/api.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+from contextlib import suppress
 from datetime import datetime, timedelta
 import json
 import logging
@@ -473,7 +474,9 @@ class Throttle:
         delay = (self._timestamp - timestamp).total_seconds()
         if delay > 0:
             _LOGGER.debug("Delaying request by %s seconds due to throttle", delay)
-            await asyncio.sleep(delay)
+            with suppress(asyncio.CancelledError):
+                await asyncio.sleep(delay)
+
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):


### PR DESCRIPTION
The issue #84 showed a possible problem during the throttling of the api calls. The `asyncio.sleep()` task can be cancelled and would raise a `CancelledError`.

After some research the most common solution in this case would be to just suppress this error.