### PR TITLE
Ignore non-enum sensors that provide text values

### DIFF
--- a/custom_components/myuplink/sensor.py
+++ b/custom_components/myuplink/sensor.py
@@ -42,6 +42,12 @@ async def async_setup_entry(
             entities.append(MyUplinkNotificationsSensorEntity(coordinator, device))
             for parameter in device.parameters:
                 if parameter.find_fitting_entity() == Platform.SENSOR:
+                    if (
+                        not parameter.unit
+                        and not len(parameter.enum_values)
+                        and not isinstance(parameter.value, (int, float))
+                    ):
+                        continue
                     entities.append(
                         MyUplinkParameterSensorEntity(coordinator, device, parameter)
                     )


### PR DESCRIPTION
This request fixes an issue I have been having with this integration and my Høiax water heater lately. 
The integration tries to register the `model_id` field coming from the API as a numeric sensor as it does not provide a unit. This again seems to cause the update of data to fail until the integration is restarted and it manages to update once before failing again. 

The response coming from the API for this point is:
```
  {
    "category": "18760NE2051223802688",
    "parameterId": "513",
    "parameterName": "Model id",
    "parameterUnit": "",
    "writable": false,
    "timestamp": "2024-04-13T08:55:37+00:00",
    "value": "18760NE2051223802688",
    "strVal": "18760NE2051223802688",
    "smartHomeCategories": [],
    "minValue": null,
    "maxValue": null,
    "stepValue": 1,
    "enumValues": [],
    "scaleValue": "1",
    "zoneId": null
  }
```  

The change I am proposing simply ignores sensors that do not provide enum options, do not have a UOM and provide a non-numeric value.

