### PR TITLE
Handle skipping string-only parameters

### DIFF
--- a/custom_components/myuplink/binary_sensor.py
+++ b/custom_components/myuplink/binary_sensor.py
@@ -1,4 +1,5 @@
 """Support for myUplink sensors."""
+
 from __future__ import annotations
 
 import logging
@@ -31,7 +32,7 @@ async def async_setup_entry(
         for device in system.devices:
             entities.append(MyUplinkConnectedBinarySensor(coordinator, device))
             for parameter in device.parameters:
-                if parameter.find_fitting_entity() == Platform.BINARY_SENSOR:
+                if parameter.fitting_entity == Platform.BINARY_SENSOR:
                     entities.append(
                         MyUplinkParameterBinarySensorEntity(
                             coordinator, device, parameter

--- a/custom_components/myuplink/number.py
+++ b/custom_components/myuplink/number.py
@@ -1,4 +1,5 @@
 """Support for myUplink sensors."""
+
 from __future__ import annotations
 
 import logging
@@ -27,7 +28,7 @@ async def async_setup_entry(
     for system in coordinator.data:
         for device in system.devices:
             for parameter in device.parameters:
-                if parameter.find_fitting_entity() == Platform.NUMBER:
+                if parameter.fitting_entity == Platform.NUMBER:
                     entities.append(
                         MyUplinkParameterNumberEntity(coordinator, device, parameter)
                     )

--- a/custom_components/myuplink/select.py
+++ b/custom_components/myuplink/select.py
@@ -1,4 +1,5 @@
 """Support for myUplink sensors."""
+
 from __future__ import annotations
 
 import logging
@@ -27,7 +28,7 @@ async def async_setup_entry(
     for system in coordinator.data:
         for device in system.devices:
             for parameter in device.parameters:
-                if parameter.find_fitting_entity() == Platform.SELECT:
+                if parameter.fitting_entity == Platform.SELECT:
                     entities.append(
                         MyUplinkParameterSelectEntity(coordinator, device, parameter)
                     )

--- a/custom_components/myuplink/sensor.py
+++ b/custom_components/myuplink/sensor.py
@@ -1,4 +1,5 @@
 """Support for myUplink sensors."""
+
 from __future__ import annotations
 
 import logging
@@ -41,7 +42,7 @@ async def async_setup_entry(
         for device in system.devices:
             entities.append(MyUplinkNotificationsSensorEntity(coordinator, device))
             for parameter in device.parameters:
-                if parameter.find_fitting_entity() == Platform.SENSOR:
+                if parameter.fitting_entity == Platform.SENSOR:
                     entities.append(
                         MyUplinkParameterSensorEntity(coordinator, device, parameter)
                     )

--- a/custom_components/myuplink/switch.py
+++ b/custom_components/myuplink/switch.py
@@ -1,4 +1,5 @@
 """Support for myUplink sensors."""
+
 from __future__ import annotations
 
 import logging
@@ -27,7 +28,7 @@ async def async_setup_entry(
     for system in coordinator.data:
         for device in system.devices:
             for parameter in device.parameters:
-                if parameter.find_fitting_entity() == Platform.SWITCH:
+                if parameter.fitting_entity == Platform.SWITCH:
                     entities.append(
                         MyUplinkParameterSwitchEntityEntity(
                             coordinator, device, parameter


### PR DESCRIPTION
I found my water heater to suddenly not load properly since last month, and found an error coming from parsing one of the parameters:
![bilde](https://github.com/jaroschek/home-assistant-myuplink/assets/16783057/53b8f616-bb98-4282-80c4-d0ce16c453e7)

<details>

<summary>The error I got</summary>

```
2024-04-23 07:13:26.217 ERROR (MainThread) [homeassistant.components.sensor] Error adding entity sensor.18760ne2220523854649_model_id for domain sensor with platform myuplink
Traceback (most recent call last):
  File "/workspaces/core/homeassistant/components/sensor/__init__.py", line 658, in state
    numerical_value = int(value)
                      ^^^^^^^^^^
ValueError: invalid literal for int() with base 10: '18760NE2220523854649'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/workspaces/core/homeassistant/components/sensor/__init__.py", line 661, in state
    numerical_value = float(value)
                      ^^^^^^^^^^^^
ValueError: could not convert string to float: '18760NE2220523854649'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/workspaces/core/homeassistant/helpers/entity_platform.py", line 580, in _async_add_entities
    await coro
  File "/workspaces/core/homeassistant/helpers/entity_platform.py", line 892, in _async_add_entity
    await entity.add_to_platform_finish()
  File "/workspaces/core/homeassistant/helpers/entity.py", line 1343, in add_to_platform_finish
    self.async_write_ha_state()
  File "/workspaces/core/homeassistant/helpers/entity.py", line 995, in async_write_ha_state
    self._async_write_ha_state()
  File "/workspaces/core/homeassistant/helpers/entity.py", line 1118, in _async_write_ha_state
    state, attr, capabilities, shadowed_attr = self.__async_calculate_state()
                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/core/homeassistant/helpers/entity.py", line 1053, in __async_calculate_state
    state = self._stringify_state(available)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/core/homeassistant/helpers/entity.py", line 1001, in _stringify_state
    if (state := self.state) is None:
                 ^^^^^^^^^^
  File "/workspaces/core/homeassistant/components/sensor/__init__.py", line 665, in state
    raise ValueError(
ValueError: Sensor sensor.18760ne2220523854649_model_id has device class 'None', state class 'None' unit '' and suggested precision 'None' thus indicating it has a numeric value; however, it has the non-numeric value: '18760NE2220523854649' (<class 'str'>)
```

</details>

When checking for fitting entity type, this one gets `sensor`. However, having just a string as a value doesn't seem to be supported. It tried casting it to int or float internally and failed, resulting in a stunted parsing process.

I implemented a check that tries casting it to int then float, and if it fails both, return a fitting_entity as `None`, thus none of the platforms will handle the parameter. The check isn't the most elegant, but python itself isn't either so I don't know if it can be done any better. Works for my setup at least, only affecting this parameter.

I also did some general tweaking of the function, and made it run once during `__init__` so it doesn't have to run everytime a platform checks. 