### PR TITLE
Update displayed naming and avoid duplicated sensors from api

### DIFF
--- a/custom_components/myuplink/entity.py
+++ b/custom_components/myuplink/entity.py
@@ -75,10 +75,10 @@ class MyUplinkParameterEntity(MyUplinkEntity):
         self._parameter = parameter
         if self._parameter.category and self._device.name != self._parameter.category:
             self._attr_name = (
-                f"{self._device.name} {self._parameter.category} {self._parameter.name}"
+                f"{self._parameter.category} {self._parameter.name} ({self._parameter.id})"
             )
         else:
-            self._attr_name = f"{self._device.name} {self._parameter.name}"
+            self._attr_name = f"{self._parameter.name} ({self._parameter.id})"
         self._attr_unique_id = f"{DOMAIN}_{self._device.id}_{self._parameter.id}"
 
     @callback


### PR DESCRIPTION
This pr aims to further improve the readability of the many many sensors we get from myuplink, at least with certain hvac-types. 
See if you approve, i have removed the device_id from the name as it was obscuring the readability. I also added the id in parenthesis in the end.

Furthermore, in api.py i've introduced a check for duplicated points since i've seen that these do occur. Imo this should not be possible but to prevent issues or missmatching sensors in HA I suggest we patch it like this til it's fixed on the myuplink-side.

When reviewing this, please do consider any implications the renaming may have for future sensor_ids. The current ids should stay the same as they did with my instance. 
Also check so that you agree with my distinct-selection in api.py

Thanks.