### PR TITLE
Add more writable overrides for Nibe S1255-6

### DIFF
--- a/custom_components/myuplink/const.py
+++ b/custom_components/myuplink/const.py
@@ -1,4 +1,5 @@
 """Constants for the myUplink integration."""
+
 from __future__ import annotations
 
 from enum import StrEnum
@@ -35,22 +36,25 @@ MIN_SCAN_INTERVAL = 5
 PLATFORM_OVERRIDE = {
     10733: Platform.BINARY_SENSOR,
     44703: Platform.BINARY_SENSOR,
-
-    47839: Platform.SWITCH,
-    47805: Platform.SWITCH,
-    47771: Platform.SWITCH,
-    47669: Platform.SWITCH,
-    47635: Platform.SWITCH,
     47050: Platform.SWITCH,
     47394: Platform.SWITCH,
-    48442: Platform.SWITCH,
-    48043: Platform.SWITCH,
-    48009: Platform.SWITCH,
+    47635: Platform.SWITCH,
+    47669: Platform.SWITCH,
+    47771: Platform.SWITCH,
+    47805: Platform.SWITCH,
+    47839: Platform.SWITCH,
     47975: Platform.SWITCH,
+    48009: Platform.SWITCH,
+    48043: Platform.SWITCH,
+    48442: Platform.SWITCH,
 }
 
 WRITABLE_OVERRIDE = {
     781: False,
+    1755: False,
+    1959: False,
+    1961: False,
+    1963: False,
     15753: False,
 }
 


### PR DESCRIPTION
Add some more writable overrides for Nibe S1255-6, because the myUplink API provides still provides non-writable parameters as writable.