### PR TITLE
Add configuration property to set everything read-only if you don't have a subscription

### DIFF
--- a/custom_components/myuplink/api.py
+++ b/custom_components/myuplink/api.py
@@ -31,6 +31,7 @@ from .const import (
     CONF_PARAMETER_WHITELIST,
     CONF_PLATFORM_OVERRIDE,
     CONF_WRITABLE_OVERRIDE,
+    CONF_WRITABLE_WITHOUT_SUBSCRIPTION,
     DEFAULT_PLATFORM_OVERRIDE,
     DEFAULT_WRITABLE_OVERRIDE,
 )
@@ -212,10 +213,12 @@ class Parameter:
     @property
     def is_writable(self) -> bool:
         """Return if the parameter is writable."""
-        if self.id in self.device.system.api.writable_override:
-            return self.device.system.api.writable_override[self.id]
+        if self.device.system.premium_manage or self.device.system.api.writable_without_subscription:
+            if self.id in self.device.system.api.writable_override:
+                return self.device.system.api.writable_override[self.id]
 
-        return self.raw_data["writable"]
+            return self.raw_data["writable"]
+        return False
 
     @property
     def timestamp(self) -> str:
@@ -577,6 +580,8 @@ class MyUplink:
         self.throttle = Throttle(timedelta(seconds=5))
 
         self.header = {"Accept-Language": language_code}
+        
+        self.writable_without_subscription = entry.options.get(CONF_WRITABLE_WITHOUT_SUBSCRIPTION, True)
 
         try:
             self.parameter_whitelist = json.loads(

--- a/custom_components/myuplink/config_flow.py
+++ b/custom_components/myuplink/config_flow.py
@@ -33,6 +33,7 @@ from .const import (
     CONF_PARAMETER_WHITELIST,
     CONF_PLATFORM_OVERRIDE,
     CONF_WRITABLE_OVERRIDE,
+    CONF_WRITABLE_WITHOUT_SUBSCRIPTION,
     DEFAULT_PLATFORM_OVERRIDE,
     DEFAULT_SCAN_INTERVAL,
     DEFAULT_WRITABLE_OVERRIDE,
@@ -125,6 +126,9 @@ def get_expert_schema(data: ConfigType) -> Schema:
                 CONF_PLATFORM_OVERRIDE,
                 default=platform_override,
             ): selector.TextSelector(selector.TextSelectorConfig(multiline=True)),
+            vol.Optional(CONF_WRITABLE_WITHOUT_SUBSCRIPTION,
+                         default=data.get(CONF_WRITABLE_WITHOUT_SUBSCRIPTION, True),
+            ): selector.BooleanSelector(),
             vol.Optional(
                 CONF_WRITABLE_OVERRIDE,
                 default=writable_override,

--- a/custom_components/myuplink/const.py
+++ b/custom_components/myuplink/const.py
@@ -42,6 +42,7 @@ CONF_FETCH_NOTIFICATIONS = "fetch_notifications"
 CONF_PARAMETER_WHITELIST = "parameter_whitelist"
 CONF_PLATFORM_OVERRIDE = "platform_override"
 CONF_WRITABLE_OVERRIDE = "writable_override"
+CONF_WRITABLE_WITHOUT_SUBSCRIPTION = "writable_without_subscription"
 
 DEFAULT_SCAN_INTERVAL = 300
 MAX_SCAN_INTERVAL = 600

--- a/custom_components/myuplink/strings.json
+++ b/custom_components/myuplink/strings.json
@@ -25,12 +25,14 @@
         "title": "Expert Settings",
         "data": {
           "platform_override": "Platform Overrides",
+          "writable_without_subscription": "Writable without subscription",
           "writable_override": "Writable Overrides",
           "parameter_whitelist": "Parameter Whitelist",
           "additional_parameter": "Additional Parameter"
         },
         "data_description": {
           "platform_override": "Force a specific platform for a given parameter ID.\n\nThis is sometimes necessary if the myUplink API provides incorrect parameter data and the integration detects the wrong platform.\n\nMust be valid JSON. To restore the default, invalidate the field and save. An empty field will cause no change.",
+          "writable_without_subscription": "When you do not have a Premium subscription and are not able to write parameter values, create writable entities in Home Assistant anyway\n\nThis is enabled by default to avoid issues with lapsed subscriptions, non-Premium users adding subscriptions, and the possibility of myUplink providing manage permissions unilaterally.",
           "writable_override": "Set specific parameter to writeable or not writeable.\n\nThis is sometimes necessary if the myUplink API provides the wrong state for the paramter option `writable`.\n\nMust be valid JSON. To restore the default, invalidate the field and save. An empty field will cause no change.",
           "parameter_whitelist": "Restriction of the requested parameters to a specific list of parameter IDs.\n\nThis can be useful if the myUplink API provides an extremely large number of parameters, some of which are unimportant, and you want to restrict the available list of parameters.\n\nList of parameter IDs separated by commas. An empty list does not result in any restriction. Must be valid JSON. To restore the default, invalidate the field and save. An empty field does not result in any change.",
           "additional_parameter": "Add additional parameter IDs to the query.\n\nIn extremely rare cases, the myUplink API does not provide all available parameters. With this list, it is possible to add known parameter IDs, which are then queried directly.\n\nComma-separated list of parameter IDs. An empty list does not result in any restrictions. Must be valid JSON. To restore the default, invalidate the field and save. An empty field does not result in any changes."
@@ -208,12 +210,14 @@
         "title": "Expert Settings",
         "data": {
           "platform_override": "Platform Overrides",
+          "writable_without_subscription": "Writable without subscription",
           "writable_override": "Writable Overrides",
           "parameter_whitelist": "Parameter Whitelist",
           "additional_parameter": "Additional Parameter"
         },
         "data_description": {
           "platform_override": "Force a specific platform for a given parameter ID.\n\nThis is sometimes necessary if the myUplink API provides incorrect parameter data and the integration detects the wrong platform.\n\nMust be valid JSON. To restore the default, invalidate the field and save. An empty field will cause no change.",
+          "writable_without_subscription": "When you do not have a Premium subscription and are not able to write parameter values, create writable entities in Home Assistant anyway\n\nThis is enabled by default to avoid issues with lapsed subscriptions, non-Premium users adding subscriptions, and the possibility of myUplink providing manage permissions unilaterally.",
           "writable_override": "Set specific parameter to writeable or not writeable.\n\nThis is sometimes necessary if the myUplink API provides the wrong state for the paramter option `writable`.\n\nMust be valid JSON. To restore the default, invalidate the field and save. An empty field will cause no change.",
           "parameter_whitelist": "Restriction of the requested parameters to a specific list of parameter IDs.\n\nThis can be useful if the myUplink API provides an extremely large number of parameters, some of which are unimportant, and you want to restrict the available list of parameters.\n\nList of parameter IDs separated by commas. An empty list does not result in any restriction. Must be valid JSON. To restore the default, invalidate the field and save. An empty field does not result in any change.",
           "additional_parameter": "Add additional parameter IDs to the query.\n\nIn extremely rare cases, the myUplink API does not provide all available parameters. With this list, it is possible to add known parameter IDs, which are then queried directly.\n\nComma-separated list of parameter IDs. An empty list does not result in any restrictions. Must be valid JSON. To restore the default, invalidate the field and save. An empty field does not result in any changes."

--- a/custom_components/myuplink/translations/da.json
+++ b/custom_components/myuplink/translations/da.json
@@ -42,12 +42,14 @@
         "title": "Ekspertindstillinger",
         "data": {
           "platform_override": "Platformtilsidesættelser",
+          "writable_without_subscription": "Skrivbar uden abonnement",
           "writable_override": "Skrivbare tilsidesættelser",
           "parameter_whitelist": "Parameterhvidliste",
           "additional_parameter": "Yderligere parameter"
         },
         "data_description": {
           "platform_override": "Tving en specifik platform til et givet parameter-id.\n\nDette er nogle gange nødvendigt, hvis myUplink API'en leverer forkerte parameterdata, og integrationen registrerer den forkerte platform.\n\nSkal være gyldig JSON. For at gendanne standarden skal du ugyldiggøre feltet og gemme. Et tomt felt medfører ingen ændring.",
+          "writable_without_subscription": "Når du ikke har et Premium-abonnement og kan ikke skrive værdier, oprette skrivbare enheder i Home Assistant alligevel.\n\nAktiveret som standard for at undgå problemer med bortfaldte abonnementer, ikke-Premium brugere som tilføjer abonnementer, og muligheden at myUplink tillader at brugere kan skrive værdier uden abonnement.",
           "writable_override": "Indstil specifik parameter til skrivbar eller ikke skrivbar.\n\nDette er nogle gange nødvendigt, hvis myUplink API'et giver den forkerte tilstand for parameterindstillingen `writable`.\n\nSkal være gyldig JSON. For at gendanne standarden skal du ugyldiggøre feltet og gemme. Et tomt felt medfører ingen ændring.",
           "parameter_whitelist": "Begrænsning af de anmodede parametre til en specifik liste over parameter-id'er.\n\nDette kan være nyttigt, hvis myUplink API'en giver et ekstremt stort antal parametre, hvoraf nogle er ligegyldige, og du ønsker at begrænse den tilgængelige liste over parametre.\n\nListe over parameter-id'er adskilt af kommaer. En tom liste medfører ikke nogen begrænsning. Skal være gyldig JSON. For at gendanne standarden skal du ugyldiggøre feltet og gemme. Et tomt felt resulterer ikke i nogen ændring.",
           "additional_parameter": "Tilføj yderligere parameter-id'er til forespørgslen.\n\nI yderst sjældne tilfælde giver myUplink API ikke alle tilgængelige parametre. Med denne liste er det muligt at tilføje kendte parameter-id'er, som derefter forespørges direkte.\n\nKommasepareret liste over parameter-id'er. En tom liste medfører ingen begrænsninger. Skal være gyldig JSON. For at gendanne standarden skal du ugyldiggøre feltet og gemme. Et tomt felt medfører ingen ændringer."
@@ -208,12 +210,14 @@
         "title": "Ekspertindstillinger",
         "data": {
           "platform_override": "Platformtilsidesættelser",
+          "writable_without_subscription": "Skrivbar uden abonnement",
           "writable_override": "Skrivbare tilsidesættelser",
           "parameter_whitelist": "Parameterhvidliste",
           "additional_parameter": "Yderligere parameter"
         },
         "data_description": {
           "platform_override": "Tving en specifik platform til et givet parameter-id.\n\nDette er nogle gange nødvendigt, hvis myUplink API'en leverer forkerte parameterdata, og integrationen registrerer den forkerte platform.\n\nSkal være gyldig JSON. For at gendanne standarden skal du ugyldiggøre feltet og gemme. Et tomt felt medfører ingen ændring.",
+          "writable_without_subscription": "Når du ikke har et Premium-abonnement og kan ikke skrive værdier, oprette skrivbare enheder i Home Assistant alligevel.\n\nAktiveret som standard for at undgå problemer med bortfaldte abonnementer, ikke-Premium brugere som tilføjer abonnementer, og muligheden at myUplink tillader at brugere kan skrive værdier uden abonnement.",
           "writable_override": "Indstil specifik parameter til skrivbar eller ikke skrivbar.\n\nDette er nogle gange nødvendigt, hvis myUplink API'et giver den forkerte tilstand for parameterindstillingen `writable`.\n\nSkal være gyldig JSON. For at gendanne standarden skal du ugyldiggøre feltet og gemme. Et tomt felt medfører ingen ændring.",
           "parameter_whitelist": "Begrænsning af de anmodede parametre til en specifik liste over parameter-id'er.\n\nDette kan være nyttigt, hvis myUplink API'en giver et ekstremt stort antal parametre, hvoraf nogle er ligegyldige, og du ønsker at begrænse den tilgængelige liste over parametre.\n\nListe over parameter-id'er adskilt af kommaer. En tom liste medfører ikke nogen begrænsning. Skal være gyldig JSON. For at gendanne standarden skal du ugyldiggøre feltet og gemme. Et tomt felt resulterer ikke i nogen ændring.",
           "additional_parameter": "Tilføj yderligere parameter-id'er til forespørgslen.\n\nI yderst sjældne tilfælde giver myUplink API ikke alle tilgængelige parametre. Med denne liste er det muligt at tilføje kendte parameter-id'er, som derefter forespørges direkte.\n\nKommasepareret liste over parameter-id'er. En tom liste medfører ingen begrænsninger. Skal være gyldig JSON. For at gendanne standarden skal du ugyldiggøre feltet og gemme. Et tomt felt medfører ingen ændringer."

--- a/custom_components/myuplink/translations/de.json
+++ b/custom_components/myuplink/translations/de.json
@@ -42,12 +42,14 @@
         "title": "Experteneinstellungen",
         "data": {
           "platform_override": "Platform-Überschreibung",
+          "writable_without_subscription": "Schreibbar ohne Abonnement",
           "writable_override": "Schreibkarkeit",
           "parameter_whitelist": "Parameter-Whitelist",
           "additional_parameter": "Zusätzliche Parameter"
         },
         "data_description": {
           "platform_override": "Erzwingen einer bestimmten Plattform für eine bestimmte Parameter-ID.\n\nDies ist manchmal erforderlich, wenn die myUplink-API falsche Parameterdaten bereitstellt und die Integration die falsche Plattform erkennt.\n\nMuss gültiges JSON sein. Um den Standard wiederherzustellen, das Feld ungültig machen und speichern. Ein leeres Feld führt zu keiner Änderung.",
+          "writable_without_subscription": "Wenn Sie kein Premium-Abonnement haben und keine Werte schreiben können, erstellen Sie trotzdem beschreibbare Geräte in Home Assistant.\n\nStandardmäßig aktiviert, um Probleme mit abgelaufenen Abonnements, Nicht-Premium-Benutzer die Abonnements hinfügen, und die Möglichkeit, dass myUplink Benutzern das Schreiben von Parameter ohne Abonnement ermöglicht.",
           "writable_override": "Setzen Sie bestimmte Parameter auf beschreibbar oder nicht beschreibbar.\n\nDies ist manchmal erforderlich, wenn die myUplink-API den falschen Status für die Parameteroption `writable` bereitstellt.\n\nMuss gültiges JSON sein. Um den Standard wiederherzustellen, das Feld ungültig machen und speichern. Ein leeres Feld führt zu keiner Änderung.",
           "parameter_whitelist": "Einschränkung der abgefragten Parameter auf eine bestimmte List an Parameter IDs.\n\nDies kann sinnvoll sein, wenn die myUplink-API extrem viele und teilweise unwichtige Parameter liefert und man die verfügbare Liste an Parametern einschränken möchte.\n\nDurch Komma getrennte Liste von Parameter-IDs. Eine leer Liste führt zu keiner Einschränkung. Muss gültiges JSON sein. Um den Standard wiederherzustellen, das Feld ungültig machen und speichern. Ein leeres Feld führt zu keiner Änderung.",
           "additional_parameter": "Zusätzliche Parameter IDs zur Abfrage hinzufügen.\n\nIn extrem seltenen Fällen liefert die myUplink-API nicht alle verfügbaren Parameter. Mit dieser Liste ist es möglich bekannte Parameter IDs zu ergänzen, die dann direkt abgefragt werden.\n\nDurch Komma getrennte Liste von Parameter-IDs. Eine leer Liste führt zu keiner Einschränkung. Muss gültiges JSON sein. Um den Standard wiederherzustellen, das Feld ungültig machen und speichern. Ein leeres Feld führt zu keiner Änderung."
@@ -174,12 +176,14 @@
         "title": "Experteneinstellungen",
         "data": {
           "platform_override": "Platform-Überschreibung",
+          "writable_without_subscription": "Schreibbar ohne Abonnement",
           "writable_override": "Schreibkarkeit",
           "parameter_whitelist": "Parameter-Whitelist",
           "additional_parameter": "Zusätzliche Parameter"
         },
         "data_description": {
           "platform_override": "Erzwingen einer bestimmten Plattform für eine bestimmte Parameter-ID.\n\nDies ist manchmal erforderlich, wenn die myUplink-API falsche Parameterdaten bereitstellt und die Integration die falsche Plattform erkennt.\n\nMuss gültiges JSON sein. Um den Standard wiederherzustellen, das Feld ungültig machen und speichern. Ein leeres Feld führt zu keiner Änderung.",
+          "writable_without_subscription": "Wenn Sie kein Premium-Abonnement haben und keine Werte schreiben können, erstellen Sie trotzdem beschreibbare Geräte in Home Assistant.\n\nStandardmäßig aktiviert, um Probleme mit abgelaufenen Abonnements, Nicht-Premium-Benutzer die Abonnements hinfügen, und die Möglichkeit, dass myUplink Benutzern das Schreiben von Parameter ohne Abonnement ermöglicht.",
           "writable_override": "Setzen Sie bestimmte Parameter auf beschreibbar oder nicht beschreibbar.\n\nDies ist manchmal erforderlich, wenn die myUplink-API den falschen Status für die Parameteroption `writable` bereitstellt.\n\nMuss gültiges JSON sein. Um den Standard wiederherzustellen, das Feld ungültig machen und speichern. Ein leeres Feld führt zu keiner Änderung.",
           "parameter_whitelist": "Einschränkung der abgefragten Parameter auf eine bestimmte List an Parameter IDs.\n\nDies kann sinnvoll sein, wenn die myUplink-API extrem viele und teilweise unwichtige Parameter liefert und man die verfügbare Liste an Parametern einschränken möchte.\n\nDurch Komma getrennte Liste von Parameter-IDs. Eine leer Liste führt zu keiner Einschränkung. Muss gültiges JSON sein. Um den Standard wiederherzustellen, das Feld ungültig machen und speichern. Ein leeres Feld führt zu keiner Änderung.",
           "additional_parameter": "Zusätzliche Parameter IDs zur Abfrage hinzufügen.\n\nIn extrem seltenen Fällen liefert die myUplink-API nicht alle verfügbaren Parameter. Mit dieser Liste ist es möglich bekannte Parameter IDs zu ergänzen, die dann direkt abgefragt werden.\n\nDurch Komma getrennte Liste von Parameter-IDs. Eine leer Liste führt zu keiner Einschränkung. Muss gültiges JSON sein. Um den Standard wiederherzustellen, das Feld ungültig machen und speichern. Ein leeres Feld führt zu keiner Änderung."

--- a/custom_components/myuplink/translations/en.json
+++ b/custom_components/myuplink/translations/en.json
@@ -42,12 +42,14 @@
         "title": "Expert Settings",
         "data": {
           "platform_override": "Platform Overrides",
+          "writable_without_subscription": "Writable without Premium",
           "writable_override": "Writable Overrides",
           "parameter_whitelist": "Parameter Whitelist",
           "additional_parameter": "Additional Parameter"
         },
         "data_description": {
           "platform_override": "Force a specific platform for a given parameter ID.\n\nThis is sometimes necessary if the myUplink API provides incorrect parameter data and the integration detects the wrong platform.\n\nMust be valid JSON. To restore the default, invalidate the field and save. An empty field will cause no change.",
+          "writable_without_subscription": "When you do not have a Premium subscription and are not able to write parameter values, create writable entities in Home Assistant anyway\n\nThis is enabled by default to avoid issues with lapsed subscriptions, non-Premium users adding subscriptions, and the possibility of myUplink providing manage permissions unilaterally.",
           "writable_override": "Set specific parameter to writeable or not writeable.\n\nThis is sometimes necessary if the myUplink API provides the wrong state for the paramter option `writable`.\n\nMust be valid JSON. To restore the default, invalidate the field and save. An empty field will cause no change.",
           "parameter_whitelist": "Restriction of the requested parameters to a specific list of parameter IDs.\n\nThis can be useful if the myUplink API provides an extremely large number of parameters, some of which are unimportant, and you want to restrict the available list of parameters.\n\nList of parameter IDs separated by commas. An empty list does not result in any restriction. Must be valid JSON. To restore the default, invalidate the field and save. An empty field does not result in any change.",
           "additional_parameter": "Add additional parameter IDs to the query.\n\nIn extremely rare cases, the myUplink API does not provide all available parameters. With this list, it is possible to add known parameter IDs, which are then queried directly.\n\nComma-separated list of parameter IDs. An empty list does not result in any restrictions. Must be valid JSON. To restore the default, invalidate the field and save. An empty field does not result in any changes."
@@ -208,12 +210,14 @@
         "title": "Expert Settings",
         "data": {
           "platform_override": "Platform Overrides",
+          "writable_without_subscription": "Writable without Premium",
           "writable_override": "Writable Overrides",
           "parameter_whitelist": "Parameter Whitelist",
           "additional_parameter": "Additional Parameter"
         },
         "data_description": {
           "platform_override": "Force a specific platform for a given parameter ID.\n\nThis is sometimes necessary if the myUplink API provides incorrect parameter data and the integration detects the wrong platform.\n\nMust be valid JSON. To restore the default, invalidate the field and save. An empty field will cause no change.",
+          "writable_without_subscription": "When you do not have a Premium subscription and are not able to write parameter values, create writable entities in Home Assistant anyway\n\nThis is enabled by default to avoid issues with lapsed subscriptions, non-Premium users adding subscriptions, and the possibility of myUplink providing manage permissions unilaterally.",
           "writable_override": "Set specific parameter to writeable or not writeable.\n\nThis is sometimes necessary if the myUplink API provides the wrong state for the paramter option `writable`.\n\nMust be valid JSON. To restore the default, invalidate the field and save. An empty field will cause no change.",
           "parameter_whitelist": "Restriction of the requested parameters to a specific list of parameter IDs.\n\nThis can be useful if the myUplink API provides an extremely large number of parameters, some of which are unimportant, and you want to restrict the available list of parameters.\n\nList of parameter IDs separated by commas. An empty list does not result in any restriction. Must be valid JSON. To restore the default, invalidate the field and save. An empty field does not result in any change.",
           "additional_parameter": "Add additional parameter IDs to the query.\n\nIn extremely rare cases, the myUplink API does not provide all available parameters. With this list, it is possible to add known parameter IDs, which are then queried directly.\n\nComma-separated list of parameter IDs. An empty list does not result in any restrictions. Must be valid JSON. To restore the default, invalidate the field and save. An empty field does not result in any changes."

--- a/custom_components/myuplink/translations/nb.json
+++ b/custom_components/myuplink/translations/nb.json
@@ -42,12 +42,14 @@
         "title": "Ekspertinnstillinger",
         "data": {
           "platform_override": "Plattformoverstyringer",
+          "writable_without_subscription": "Skrivbar uten abonnement",
           "writable_override": "Skrivbare overstyringer",
           "parameter_whitelist": "Parameterhviteliste",
           "additional_parameter": "Tilleggsparameter"
         },
         "data_description": {
           "platform_override": "Tving frem en spesifikk plattform for en gitt parameter-ID.\n\nDette er noen ganger nødvendig hvis myUplink API gir feil parameterdata og integrasjonen oppdager feil plattform.\n\nMå være gyldig JSON. For å gjenopprette standarden, ugyldiggjør feltet og lagre. Et tomt felt vil ikke forårsake noen endring.",
+          "writable_without_subscription": "Når du ikke har et Premium-abonnement og ikke kan skrive verdier, lag skrivbare enheter i Home Assistant uansett.\n\nAktivert som standard for å unngå problemer med utgåtte abonnementer, ikke-Premium-brukere som legger til abonnementer og muligheten for at myUplink lar brukere skrive verdier uten abonnement.",
           "writable_override": "Sett spesifikk parameter til skrivbar eller ikke skrivbar.\n\nDette er noen ganger nødvendig hvis myUplink API gir feil tilstand for parameteralternativet `writable`.\n\nMå være gyldig JSON. For å gjenopprette standarden, ugyldiggjør feltet og lagre. Et tomt felt vil ikke forårsake noen endring.",
           "parameter_whitelist": "Begrensning av de forespurte parameterne til en spesifikk liste med parameter-ID-er.\n\nDette kan være nyttig hvis myUplink API gir et ekstremt stort antall parametere, hvorav noen er uviktige, og du ønsker å begrense den tilgjengelige listen over parametere.\n\nListe over parameter-ID-er atskilt med komma. En tom liste resulterer ikke i noen begrensning. Må være gyldig JSON. For å gjenopprette standarden, ugyldiggjør feltet og lagre. Et tomt felt resulterer ikke i noen endring.",
           "additional_parameter": "Legg til flere parameter-IDer i spørringen.\n\nI ekstremt sjeldne tilfeller gir ikke myUplink API alle tilgjengelige parametere. Med denne listen er det mulig å legge til kjente parameter-IDer, som deretter spørres direkte.\n\nKommaseparert liste over parameter-ID-er. En tom liste medfører ingen restriksjoner. Må være gyldig JSON. For å gjenopprette standarden, ugyldiggjør feltet og lagre. Et tomt felt resulterer ikke i noen endringer."
@@ -255,12 +257,14 @@
         "title": "Ekspertinnstillinger",
         "data": {
           "platform_override": "Plattformoverstyringer",
+          "writable_without_subscription": "Skrivbar uten abonnement",
           "writable_override": "Skrivbare overstyringer",
           "parameter_whitelist": "Parameterhviteliste",
           "additional_parameter": "Tilleggsparameter"
         },
         "data_description": {
           "platform_override": "Tving frem en spesifikk plattform for en gitt parameter-ID.\n\nDette er noen ganger nødvendig hvis myUplink API gir feil parameterdata og integrasjonen oppdager feil plattform.\n\nMå være gyldig JSON. For å gjenopprette standarden, ugyldiggjør feltet og lagre. Et tomt felt vil ikke forårsake noen endring.",
+          "writable_without_subscription": "Når du ikke har et Premium-abonnement og ikke kan skrive verdier, lag skrivbare enheter i Home Assistant uansett.\n\nAktivert som standard for å unngå problemer med utgåtte abonnementer, ikke-Premium-brukere som legger til abonnementer og muligheten for at myUplink lar brukere skrive verdier uten abonnement.",
           "writable_override": "Sett spesifikk parameter til skrivbar eller ikke skrivbar.\n\nDette er noen ganger nødvendig hvis myUplink API gir feil tilstand for parameteralternativet `writable`.\n\nMå være gyldig JSON. For å gjenopprette standarden, ugyldiggjør feltet og lagre. Et tomt felt vil ikke forårsake noen endring.",
           "parameter_whitelist": "Begrensning av de forespurte parameterne til en spesifikk liste med parameter-ID-er.\n\nDette kan være nyttig hvis myUplink API gir et ekstremt stort antall parametere, hvorav noen er uviktige, og du ønsker å begrense den tilgjengelige listen over parametere.\n\nListe over parameter-ID-er atskilt med komma. En tom liste resulterer ikke i noen begrensning. Må være gyldig JSON. For å gjenopprette standarden, ugyldiggjør feltet og lagre. Et tomt felt resulterer ikke i noen endring.",
           "additional_parameter": "Legg til flere parameter-IDer i spørringen.\n\nI ekstremt sjeldne tilfeller gir ikke myUplink API alle tilgjengelige parametere. Med denne listen er det mulig å legge til kjente parameter-IDer, som deretter spørres direkte.\n\nKommaseparert liste over parameter-ID-er. En tom liste medfører ingen restriksjoner. Må være gyldig JSON. For å gjenopprette standarden, ugyldiggjør feltet og lagre. Et tomt felt resulterer ikke i noen endringer."


### PR DESCRIPTION
With this option, users who don't have a subscription can easily make all entities read-only, regardless of whether the API says they're writable.

Tested toggling the switch repeatedly on my non-premium account; switches between entities showing as read-only and writable.  Should have no effect on premium users.

Translations added for English (native speaker), Danish (certified level B2), Norwegian (machine translated from Danish as they're pretty close; looks OK to my untrained eye) and German (machine translated from Danish; looks OK to me but I last studied German many years ago).  May need to force refresh the browser if the strings don't show up.