### PR TITLE
Skip checking for brand files in HACS validation

### DIFF
--- a/.github/workflows/hacs.yaml
+++ b/.github/workflows/hacs.yaml
@@ -16,3 +16,4 @@ jobs:
         uses: "hacs/action@main"
         with:
           category: "integration"
+          ignore: "brands"


### PR DESCRIPTION
Makes HACS validation pass after that brand files were moved to core.

I had same experience/problem as you in another repo with domain name clash. This fix made everything work again.